### PR TITLE
fix: brits on cuda

### DIFF
--- a/pypots/__version__.py
+++ b/pypots/__version__.py
@@ -21,4 +21,4 @@ pypots version
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 
-version = '0.0.3'
+version = '0.0.dev32'

--- a/pypots/imputation/base.py
+++ b/pypots/imputation/base.py
@@ -140,7 +140,7 @@ class BaseNNImputer(BaseNNModel, BaseImputer):
                                'Model will load the best parameters so far for testing. '
                                "If you don't want it, please try fit() again.")
 
-        if torch.equal(self.best_loss.float(), torch.tensor(float('inf'), device=self.device)):
+        if self.best_loss.item() == float('inf'):
             raise ValueError('Something is wrong. best_loss is Nan after training.')
 
         print('Finished training.')

--- a/pypots/imputation/base.py
+++ b/pypots/imputation/base.py
@@ -140,7 +140,7 @@ class BaseNNImputer(BaseNNModel, BaseImputer):
                                'Model will load the best parameters so far for testing. '
                                "If you don't want it, please try fit() again.")
 
-        if self.best_loss.item() == float('inf'):
+        if self.best_loss == float('inf'):
             raise ValueError('Something is wrong. best_loss is Nan after training.')
 
         print('Finished training.')

--- a/pypots/imputation/base.py
+++ b/pypots/imputation/base.py
@@ -140,7 +140,7 @@ class BaseNNImputer(BaseNNModel, BaseImputer):
                                'Model will load the best parameters so far for testing. '
                                "If you don't want it, please try fit() again.")
 
-        if torch.equal(self.best_loss, torch.tensor(float('inf'), device=self.device)):
+        if torch.equal(self.best_loss.float(), torch.tensor(float('inf'), device=self.device)):
             raise ValueError('Something is wrong. best_loss is Nan after training.')
 
         print('Finished training.')

--- a/pypots/imputation/brits.py
+++ b/pypots/imputation/brits.py
@@ -491,7 +491,7 @@ class BRITS(BaseNNImputer):
         if val_X is not None:
             val_X = self.check_input(self.n_steps, self.n_features, val_X)
 
-        training_set = DatasetForBRITS(train_X)  # time_gaps is necessary for BRITS
+        training_set = DatasetForBRITS(train_X, device=self.device)  # time_gaps is necessary for BRITS
         training_loader = DataLoader(training_set, batch_size=self.batch_size, shuffle=True)
 
         if val_X is None:
@@ -499,7 +499,7 @@ class BRITS(BaseNNImputer):
         else:
             val_X_intact, val_X, val_X_missing_mask, val_X_indicating_mask = mcar(val_X, 0.2)
             val_X = masked_fill(val_X, 1 - val_X_missing_mask, torch.nan)
-            val_set = DatasetForBRITS(val_X)
+            val_set = DatasetForBRITS(val_X, device=self.device)
             val_loader = DataLoader(val_set, batch_size=self.batch_size, shuffle=False)
             self._train_model(training_loader, val_loader, val_X_intact, val_X_indicating_mask)
 
@@ -542,7 +542,7 @@ class BRITS(BaseNNImputer):
     def impute(self, X):
         X = self.check_input(self.n_steps, self.n_features, X)
         self.model.eval()  # set the model as eval status to freeze it.
-        test_set = DatasetForBRITS(X)
+        test_set = DatasetForBRITS(X, device=self.device)
         test_loader = DataLoader(test_set, batch_size=self.batch_size, shuffle=False)
         imputation_collector = []
 

--- a/pypots/tests/test_imputation.py
+++ b/pypots/tests/test_imputation.py
@@ -99,21 +99,21 @@ class TestBRITS(unittest.TestCase):
         self.brits.fit(self.train_X, self.val_X)
 
     def test_parameters(self):
-        assert (hasattr(self.brits, 'model')
+        self.assertTrue(hasattr(self.brits, 'model')
                 and self.brits.model is not None)
 
-        assert (hasattr(self.brits, 'optimizer')
+        self.assertTrue(hasattr(self.brits, 'optimizer')
                 and self.brits.optimizer is not None)
 
-        assert hasattr(self.brits, 'best_loss')
+        self.assertTrue(hasattr(self.brits, 'best_loss'))
         self.assertNotEqual(self.brits.best_loss, float('inf'))
 
-        assert (hasattr(self.brits, 'best_model_dict')
+        self.assertTrue(hasattr(self.brits, 'best_model_dict')
                 and self.brits.best_model_dict is not None)
 
     def test_impute(self):
         imputed_X = self.brits.impute(self.test_X)
-        assert not np.isnan(imputed_X).any(), 'Output still has missing values after running impute().'
+        self.assertFalse(np.isnan(imputed_X).any()), 'Output still has missing values after running impute().'
         test_MAE = cal_mae(imputed_X, self.test_X_intact, self.test_X_indicating_mask)
         print(f'BRITS test_MAE: {test_MAE}')
 

--- a/pypots/tests/test_imputation.py
+++ b/pypots/tests/test_imputation.py
@@ -134,7 +134,7 @@ class TestLOCF(unittest.TestCase):
 
     def test_impute(self):
         test_X_imputed = self.locf.impute(self.test_X)
-        assert not np.isnan(test_X_imputed).any(), 'Output still has missing values after running impute().'
+        self.assertFalse(np.isnan(test_X_imputed).any()) #  'Output still has missing values after running impute().'
         test_MAE = cal_mae(test_X_imputed, self.test_X_intact, self.test_X_indicating_mask)
         print(f'LOCF test_MAE: {test_MAE}')
 

--- a/pypots/tests/test_imputation.py
+++ b/pypots/tests/test_imputation.py
@@ -95,7 +95,7 @@ class TestBRITS(unittest.TestCase):
         self.test_X_intact = DATA['test_X_intact']
         self.test_X_indicating_mask = DATA['test_X_indicating_mask']
         print('Running test cases for BRITS...')
-        self.brits = BRITS(DATA['n_steps'], DATA['n_features'], 256, epochs=EPOCH)
+        self.brits = BRITS(DATA['n_steps'], DATA['n_features'], 10, epochs=EPOCH)
         self.brits.fit(self.train_X, self.val_X)
 
     def test_parameters(self):


### PR DESCRIPTION
Some tensors created on the fly (mainly in `base.py` and `dataset_for_brits.py` ) used to ignore the model's and data's device (cpu or gpu). This caused BRITS to throw errors whenever users wanted to run it on cuda enabled machine.