### PR TITLE
refactor: explicit channels in conda env ymls

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,6 @@ dependencies:
     - conda-forge::pip
     - pyg::pyg
     - pip:
+        - torchdiffeq
         - pycorruptor
         - tsdb
-        - torchdiffeq

--- a/environment.yml
+++ b/environment.yml
@@ -13,9 +13,9 @@ dependencies:
     - conda-forge::matplotlib
     - conda-forge::tensorboard
     - pytorch::pytorch>=1.10
-    - pyg::pyg
     - conda-forge::pip
+    - conda-forge::torchdiffeq
+    - pyg::pyg
     - pip:
-        - torchdiffeq
         - pycorruptor
         - tsdb

--- a/environment.yml
+++ b/environment.yml
@@ -3,18 +3,18 @@ channels:
     - pytorch
     - pyg
     - conda-forge
-    - defaults
+    - nodefaults
 dependencies:
-    - python=3.7.13
-    - pip
-    - numpy
-    - scipy
-    - pandas
-    - scikit-learn
-    - matplotlib
-    - tensorboard
-    - pytorch>=1.10
-    - pyg
+    - conda-forge::python>=3.7.13
+    - conda-forge::numpy
+    - conda-forge::scipy
+    - conda-forge::pandas>=1.4.1
+    - conda-forge::scikit-learn
+    - conda-forge::matplotlib
+    - conda-forge::tensorboard
+    - pytorch::pytorch>=1.10
+    - pyg::pyg
+    - conda-forge::pip
     - pip:
         - torchdiffeq
         - pycorruptor

--- a/environment.yml
+++ b/environment.yml
@@ -5,17 +5,17 @@ channels:
     - conda-forge
     - nodefaults
 dependencies:
-    - conda-forge::python>=3.7.13
+    - main::python=3.7.13
+    - conda-forge::pip
     - conda-forge::numpy
     - conda-forge::scipy
-    - conda-forge::pandas>=1.4.1
+    - conda-forge::pandas
     - conda-forge::scikit-learn
     - conda-forge::matplotlib
     - conda-forge::tensorboard
     - pytorch::pytorch>=1.10
-    - conda-forge::pip
     - pyg::pyg
     - pip:
-        - torchdiffeq
-        - pycorruptor
-        - tsdb
+        - torchdiffeq==0.2.3
+        - pycorruptor==0.0.4
+        - tsdb==0.0.7

--- a/environment.yml
+++ b/environment.yml
@@ -14,8 +14,8 @@ dependencies:
     - conda-forge::tensorboard
     - pytorch::pytorch>=1.10
     - conda-forge::pip
-    - conda-forge::torchdiffeq
     - pyg::pyg
     - pip:
         - pycorruptor
         - tsdb
+        - torchdiffeq

--- a/pypots/tests/environment_test.yml
+++ b/pypots/tests/environment_test.yml
@@ -19,6 +19,6 @@ dependencies:
     - conda-forge::pip
     - pyg::pyg
     - pip:
+          - torchdiffeq
           - pycorruptor
           - tsdb
-          - torchdiffeq

--- a/pypots/tests/environment_test.yml
+++ b/pypots/tests/environment_test.yml
@@ -16,9 +16,9 @@ dependencies:
     - conda-forge::pytest-cov
     - conda-forge::pytest-xdist
     - conda-forge::coverage
-    - conda-forge::torchdiffeq
     - conda-forge::pip
     - pyg::pyg
     - pip:
           - pycorruptor
           - tsdb
+          - torchdiffeq

--- a/pypots/tests/environment_test.yml
+++ b/pypots/tests/environment_test.yml
@@ -6,17 +6,17 @@ channels:
     - nodefaults
 dependencies:
     - pyg::pyg
-    - pytorch::pytorch>=1.10
-    - conda-forge::pip
-    - conda-forge::numpy
-    - conda-forge::scipy
-    - conda-forge::pandas
-    - conda-forge::scikit-learn
-    - conda-forge::matplotlib
-    - conda-forge::tensorboard
-    - conda-forge::pytest-cov
-    - conda-forge::pytest-xdist
-    - conda-forge::coverage
+    - pytorch::pytorch==1.10
+    - conda-forge::pip==22.2
+    - conda-forge::numpy>=1.21.6
+    - conda-forge::scipy>=1.7.3
+    - conda-forge::pandas>=1.3.5
+    - conda-forge::scikit-learn>=1.0.2
+    - conda-forge::matplotlib==3.5.2
+    - conda-forge::tensorboard==2.9.1
+    - conda-forge::pytest-cov==3.0.0
+    - conda-forge::pytest-xdist==2.5.0
+    - conda-forge::coverage==6.4.2
     - pip:
         - torchdiffeq==0.2.3
         - pycorruptor==0.0.4

--- a/pypots/tests/environment_test.yml
+++ b/pypots/tests/environment_test.yml
@@ -5,20 +5,19 @@ channels:
     - conda-forge
     - nodefaults
 dependencies:
-    - conda-forge::python>=3.7.13
+    - pyg::pyg
+    - pytorch::pytorch>=1.10
+    - conda-forge::pip
     - conda-forge::numpy
     - conda-forge::scipy
+    - conda-forge::pandas
     - conda-forge::scikit-learn
-    - conda-forge::pandas>=1.4.1
     - conda-forge::matplotlib
     - conda-forge::tensorboard
-    - conda-forge::pytorch>=1.10
     - conda-forge::pytest-cov
     - conda-forge::pytest-xdist
     - conda-forge::coverage
-    - conda-forge::pip
-    - pyg::pyg
     - pip:
-          - torchdiffeq
-          - pycorruptor
-          - tsdb
+        - torchdiffeq==0.2.3
+        - pycorruptor==0.0.4
+        - tsdb==0.0.7

--- a/pypots/tests/environment_test.yml
+++ b/pypots/tests/environment_test.yml
@@ -5,18 +5,18 @@ channels:
     - conda-forge
     - nodefaults
 dependencies:
-    - pyg::pyg
+    - pyg::pyg==2.0.4
     - pytorch::pytorch>=1.10
-    - conda-forge::pip
-    - conda-forge::numpy
-    - conda-forge::scipy
-    - conda-forge::pandas
-    - conda-forge::scikit-learn
-    - conda-forge::matplotlib
-    - conda-forge::tensorboard
-    - conda-forge::pytest-cov
-    - conda-forge::pytest-xdist
-    - conda-forge::coverage
+    - conda-forge::pip==22.2
+    - conda-forge::numpy==1.23.1
+    - conda-forge::scipy==1.8.1
+    - conda-forge::pandas==1.4.3
+    - conda-forge::scikit-learn==1.1.1
+    - conda-forge::matplotlib==3.5.2
+    - conda-forge::tensorboard==2.9.1
+    - conda-forge::pytest-cov==3.0.0
+    - conda-forge::pytest-xdist==2.5.0
+    - conda-forge::coverage==6.4.2
     - pip:
         - torchdiffeq==0.2.3
         - pycorruptor==0.0.4

--- a/pypots/tests/environment_test.yml
+++ b/pypots/tests/environment_test.yml
@@ -3,20 +3,22 @@ channels:
     - pytorch
     - pyg
     - conda-forge
-    - defaults
+    - nodefaults
 dependencies:
-    - numpy
-    - scipy
-    - pandas
-    - scikit-learn
-    - matplotlib
-    - tensorboard
-    - pytorch>=1.10
-    - pyg
-    - pytest-cov
-    - pytest-xdist
-    - coverage
+    - conda-forge::python>=3.7.13
+    - conda-forge::numpy
+    - conda-forge::scipy
+    - conda-forge::scikit-learn
+    - conda-forge::pandas>=1.4.1
+    - conda-forge::matplotlib
+    - conda-forge::tensorboard
+    - conda-forge::pytorch>=1.10
+    - conda-forge::pytest-cov
+    - conda-forge::pytest-xdist
+    - conda-forge::coverage
+    - conda-forge::torchdiffeq
+    - conda-forge::pip
+    - pyg::pyg
     - pip:
-          - torchdiffeq
           - pycorruptor
           - tsdb

--- a/pypots/tests/environment_test.yml
+++ b/pypots/tests/environment_test.yml
@@ -5,18 +5,18 @@ channels:
     - conda-forge
     - nodefaults
 dependencies:
-    - pyg::pyg==2.0.4
+    - pyg::pyg
     - pytorch::pytorch>=1.10
-    - conda-forge::pip==22.2
-    - conda-forge::numpy==1.23.1
-    - conda-forge::scipy==1.8.1
-    - conda-forge::pandas==1.4.3
-    - conda-forge::scikit-learn==1.1.1
-    - conda-forge::matplotlib==3.5.2
-    - conda-forge::tensorboard==2.9.1
-    - conda-forge::pytest-cov==3.0.0
-    - conda-forge::pytest-xdist==2.5.0
-    - conda-forge::coverage==6.4.2
+    - conda-forge::pip
+    - conda-forge::numpy
+    - conda-forge::scipy
+    - conda-forge::pandas
+    - conda-forge::scikit-learn
+    - conda-forge::matplotlib
+    - conda-forge::tensorboard
+    - conda-forge::pytest-cov
+    - conda-forge::pytest-xdist
+    - conda-forge::coverage
     - pip:
         - torchdiffeq==0.2.3
         - pycorruptor==0.0.4


### PR DESCRIPTION
Hi! You may have noticed that, when creating a new conda environment from *.yml file, it takes ages to solve package dependencies.
I attempt to speed the process up by explicitly defining channel in which to search for a package. I also defined minimal pandas version to be `1.4.1` - the things were weird before that. I also allow for python versions newer than `3.7.13` and I believe you'll find it acceptable.

Please let me know if this is in any way helpful.