### PR TITLE
Make imputation models `val_X_intact` and `val_indicating_mask` be included in input `val_set` originally

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
               with:
                   activate-environment: pypots-test
                   python-version: ${{ matrix.python-version }}
-                  environment-file: pypots/tests/environment_test.yml
+                  environment-file: pypots/tests/test_environment_conda.yml
                   auto-activate-base: false
 
             - name: Fetch the test environment details

--- a/.github/workflows/testing_daily.yml
+++ b/.github/workflows/testing_daily.yml
@@ -4,7 +4,7 @@ on:
     schedule:
         # see https://crontab.guru
         # Run "At 03:00 on Monday, Wednesday, Friday, and Sunday."
-        -   cron: '0 3 * * 1,3,5,7'
+        - cron: '0 3 * * 1,3,5,7'
 
 jobs:
     test:

--- a/.github/workflows/testing_daily.yml
+++ b/.github/workflows/testing_daily.yml
@@ -1,0 +1,42 @@
+name: Daily Testing
+
+on:
+    schedule:
+        # see https://crontab.guru
+        # Run "At 03:00 on Monday, Wednesday, Friday, and Sunday."
+        -   cron: '0 3 * * 1,3,5,7'
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+        defaults:
+            run:
+                shell: bash -l {0}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest, windows-latest, macOS-latest]
+                python-version: ["3.7", "3.9", "3.10"]
+
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install -r pypots/test_environment_pip.txt
+
+            - name: Fetch the test environment details
+              run: |
+                  which python
+                  pip list
+
+            - name: Test with pytest
+              run: |
+                  coverage run --source=pypots -m pytest
+
+            - name: Submit the report
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  coveralls --service=github

--- a/.github/workflows/testing_daily.yml
+++ b/.github/workflows/testing_daily.yml
@@ -3,8 +3,8 @@ name: Daily Testing
 on:
     schedule:
         # see https://crontab.guru
-        # Run "At 03:00 on Monday, Wednesday, Friday, and Sunday."
-        - cron: '0 3 * * 1,3,5,7'
+        # Run "At 03:00 on Sunday, Tuesday, Thursday, and Saturday."
+        - cron: '0 3 * * 0,2,4,6'
 
 jobs:
     test:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
     </a>
     <!-- Coveralls report -->
     <a alt='Coveralls report' href='https://coveralls.io/github/WenjieDu/PyPOTS'> 
-        <img src='https://img.shields.io/coverallsCoverage/github/WenjieDu/PyPOTS?branch=main&logo=coveralls&labelColor=#0aa344'>
+        <img src='https://img.shields.io/coverallsCoverage/github/WenjieDu/PyPOTS?branch=main&logo=coveralls'>
     </a>
 </p>
 
@@ -69,7 +69,7 @@ Install the latest release from PyPI:
 > pip install pypots
 
 or install from the source code with the latest features not officially released in a version:
-> pip install `https://github.com/WenjieDu/PyPOTS/archive/main.zip`
+> pip install https://github.com/WenjieDu/PyPOTS/archive/main.zip
 
 <details open>
 <summary><b>Below is an example applying SAITS in PyPOTS to impute missing values in the dataset PhysioNet2012:</b></summary>
@@ -99,19 +99,34 @@ mae = cal_mae(imputation, X_intact, indicating_mask)  # calculate mean absolute 
 </details>
 
 ## ❖ Available Algorithms
-| Task                          | Type           | Algorithm                                                                | Year | Reference |        
-|-------------------------------|----------------|--------------------------------------------------------------------------|------|-----------|
-| Imputation                    | Neural Network | SAITS (Self-Attention-based Imputation for Time Series)                  | 2023 | [^1]      |
-| Imputation                    | Neural Network | Transformer                                                              | 2017 | [^1] [^2] |
-| Imputation,<br>Classification | Neural Network | BRITS (Bidirectional Recurrent Imputation for Time Series)               | 2018 | [^3]      |
-| Imputation                    | Naive          | LOCF (Last Observation Carried Forward)                                  | -    | -         |
-| Classification                | Neural Network | GRU-D                                                                    | 2018 | [^4]      |
-| Classification                | Neural Network | Raindrop                                                                 | 2022 | [^5]      |
-| Clustering                    | Neural Network | CRLI (Clustering Representation Learning on Incomplete time-series data) | 2021 | [^6]      |
-| Clustering                    | Neural Network | VaDER (Variational Deep Embedding with Recurrence)                       | 2019 | [^7]      |
-| Forecasting                   | Probabilistic  | BTTF (Bayesian Temporal Tensor Factorization)                            | 2021 | [^8]      |
+PyPOTS supports imputation, classification, clustering, and forecasting tasks on multivariate time series with missing values. The currently available algorithms are cataloged in the following tables for each task. The paper references are all listed at the bottom of this readme file. Please refer to them if you want more details.
 
-## ❖ Reference
+### ◆ Imputation
+| Type           | Abbr.       | Algorithm / Model / Full paper name                                                                                                                                                          | Year |        
+|----------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|
+| Neural Network | SAITS       | Self-Attention-based Imputation for Time Series [^1]                                                                                                                                         | 2023 |
+| Neural Network | Transformer | Attention is All you Need [^2]; Self-Attention-based Imputation for Time Series [^1]<br><sub>Note: Transformer is proposed in [^2], and re-implemented as an imputation model in [^1].</sub> | 2017 |
+| Neural Network | BRITS       | Bidirectional Recurrent Imputation for Time Series [^3]                                                                                                                                      | 2018 |
+| Naive          | LOCF        | Last Observation Carried Forward                                                                                                                                                             | -    |
+
+### ◆ Classification
+| Type           | Abbr.    | Algorithm / Model / Full paper name                                             | Year |        
+|----------------|----------|---------------------------------------------------------------------------------|------|
+| Neural Network | BRITS    | Bidirectional Recurrent Imputation for Time Series [^3]                         | 2018 |
+| Neural Network | GRU-D    | Recurrent Neural Networks for Multivariate Time Series with Missing Values [^4] | 2018 |
+| Neural Network | Raindrop | Graph-Guided Network for Irregularly Sampled Multivariate Time Series [^5]      | 2022 |
+
+### ◆ Clustering
+| Type           | Abbr.  | Algorithm / Model / Full paper name                                    | Year |        
+|----------------|--------|------------------------------------------------------------------------|------|
+| Neural Network | CRLI   | Clustering Representation Learning on Incomplete time-series data [^6] | 2021 |
+| Neural Network | VaDER  | Variational Deep Embedding with Recurrence [^7]                        | 2019 |
+
+### ◆ Forecasting
+| Type           | Abbr.  | Algorithm / Model / Full paper name         | Year |        
+|----------------|--------|---------------------------------------------|------|
+| Probabilistic  | BTTF   | Bayesian Temporal Tensor Factorization [^8] | 2021 |
+
 ## ❖ Cite PyPOTS
 If you find PyPOTS is helpful to your research, please cite it as below and ⭐️star this repository to make others notice this work. 🤗
 

--- a/pypots/imputation/base.py
+++ b/pypots/imputation/base.py
@@ -218,8 +218,6 @@ class BaseNNImputer(BaseNNModel, BaseImputer):
         self,
         training_loader: DataLoader,
         val_loader: DataLoader = None,
-        val_X_intact: np.ndarray = None,  # TODO: move val_X_intact and val_indicating_mask into val_loader
-        val_indicating_mask: np.ndarray = None,
     ) -> None:
         self.optimizer = torch.optim.Adam(
             self.model.parameters(), lr=self.lr, weight_decay=self.weight_decay
@@ -259,7 +257,10 @@ class BaseNNImputer(BaseNNModel, BaseImputer):
                     imputation_collector = imputation_collector.numpy()
 
                     mean_val_loss = cal_mae(
-                        imputation_collector, val_X_intact, val_indicating_mask
+                        imputation_collector,
+                        val_loader.dataset.data["X_intact"],
+                        val_loader.dataset.data["indicating_mask"],
+                        # the above val_loader.dataset.data is a dict containing the validation dataset
                     )
                     self.logger["validating_loss"].append(mean_val_loss)
                     logger.info(

--- a/pypots/imputation/transformer.py
+++ b/pypots/imputation/transformer.py
@@ -11,6 +11,7 @@ Partial implementation uses code from https://github.com/WenjieDu/SAITS.
 
 from typing import Tuple, Union, Optional
 
+import h5py
 import numpy as np
 import torch
 import torch.nn as nn
@@ -19,7 +20,6 @@ from torch.utils.data import DataLoader
 
 from pypots.data.base import BaseDataset
 from pypots.data.dataset_for_mit import DatasetForMIT
-from pypots.data.utils import mcar, masked_fill
 from pypots.imputation.base import BaseNNImputer
 from pypots.utils.metrics import cal_mae
 
@@ -450,17 +450,19 @@ class Transformer(BaseNNImputer):
             self._train_model(training_loader)
         else:
             if isinstance(val_set, str):
-                import h5py
-
                 with h5py.File(val_set, "r") as hf:
-                    val_X = hf["X"]
-                val_set = {"X": val_X}
+                    # Here we read the whole validation set from the file to mask a portion for validation.
+                    # In PyPOTS, using a file usually because the data is too big. However, the validation set is
+                    # generally shouldn't be too large. For example, we have 1 billion samples for model training.
+                    # We won't take 20% of them as the validation set because we want as much as possible data for the
+                    # training stage to enhance the model's generalization ability. Therefore, 100,000 representative
+                    # samples will be enough to validate the model.
+                    val_set = {
+                        "X": hf["X"][:],
+                        "X_intact": hf["X_intact"][:],
+                        "indicating_mask": hf["indicating_mask"][:],
+                    }
 
-            val_X_intact, val_X, val_X_missing_mask, val_X_indicating_mask = mcar(
-                val_set["X"], 0.2
-            )
-            val_X = masked_fill(val_X, 1 - val_X_missing_mask, np.nan)
-            val_set["X"] = val_X
             val_set = BaseDataset(val_set)
             val_loader = DataLoader(
                 val_set,
@@ -468,9 +470,7 @@ class Transformer(BaseNNImputer):
                 shuffle=False,
                 num_workers=self.num_workers,
             )
-            self._train_model(
-                training_loader, val_loader, val_X_intact, val_X_indicating_mask
-            )
+            self._train_model(training_loader, val_loader)
 
         self.model.load_state_dict(self.best_model_dict)
         self.model.eval()  # set the model as eval status to freeze it.

--- a/pypots/tests/test_data.py
+++ b/pypots/tests/test_data.py
@@ -91,14 +91,21 @@ class TestLazyLoadingClasses(unittest.TestCase):
             save_data_set_into_h5({"X": DATA["train_X"]}, IMPUTATION_TRAIN_SET)
 
         if not os.path.exists(IMPUTATION_VAL_SET):
-            save_data_set_into_h5({"X": DATA["val_X"]}, IMPUTATION_VAL_SET)
+            save_data_set_into_h5(
+                {
+                    "X": DATA["val_X"],
+                    "X_intact": DATA["val_X_intact"],
+                    "indicating_mask": DATA["val_X_indicating_mask"],
+                },
+                IMPUTATION_VAL_SET,
+            )
 
         if not os.path.exists(TEST_SET):
             save_data_set_into_h5(
                 {
                     "X": DATA["test_X"],
                     "X_intact": DATA["test_X_intact"],
-                    "X_indicating_mask": DATA["test_X_indicating_mask"],
+                    "indicating_mask": DATA["test_X_indicating_mask"],
                 },
                 TEST_SET,
             )

--- a/pypots/tests/test_environment_conda.yml
+++ b/pypots/tests/test_environment_conda.yml
@@ -6,13 +6,13 @@ channels:
     - nodefaults
 dependencies:
     - conda-forge::python
-    - conda-forge::numpy
+    - conda-forge::pip
     - conda-forge::scipy
+    - conda-forge::numpy    # numpy should >= 1.23.3, otherwise may encounter "number not available" when torch>1.11
+    - conda-forge::scikit-learn # sklearn should >= 0.24.1
     - conda-forge::pandas
-    - conda-forge::scikit-learn
     - conda-forge::h5py
     - conda-forge::tensorboard
-    - conda-forge::pip
     - conda-forge::pytest-cov
     - conda-forge::pytest-xdist
     - conda-forge::coverage

--- a/pypots/tests/test_environment_pip.txt
+++ b/pypots/tests/test_environment_pip.txt
@@ -1,0 +1,15 @@
+scipy
+numpy
+scikit-learn
+pandas
+h5py
+tensorboard
+pytest
+coveralls
+coverage
+pycorruptor
+tsdb
+torch
+torch_sparse
+torch_scatter
+torch_geometric

--- a/pypots/tests/test_imputation.py
+++ b/pypots/tests/test_imputation.py
@@ -24,7 +24,11 @@ from pypots.utils.metrics import cal_mae
 EPOCH = 5
 
 TRAIN_SET = {"X": DATA["train_X"]}
-VAL_SET = {"X": DATA["val_X"]}
+VAL_SET = {
+    "X": DATA["val_X"],
+    "X_intact": DATA["val_X_intact"],
+    "indicating_mask": DATA["val_X_indicating_mask"],
+}
 TEST_SET = {"X": DATA["test_X"]}
 
 

--- a/pypots/tests/unified_data_for_test.py
+++ b/pypots/tests/unified_data_for_test.py
@@ -47,6 +47,10 @@ def gene_random_walk_data(
     val_X = val_X.reshape(-1, n_steps, n_features)
     test_X = test_X.reshape(-1, n_steps, n_features)
 
+    # mask values in the validation set as ground truth
+    val_X_intact, val_X, val_X_missing_mask, val_X_indicating_mask = mcar(val_X, 0.3)
+    val_X = masked_fill(val_X, 1 - val_X_missing_mask, torch.nan)
+
     # mask values in the test set as ground truth
     test_X_intact, test_X, test_X_missing_mask, test_X_indicating_mask = mcar(
         test_X, 0.3
@@ -61,6 +65,8 @@ def gene_random_walk_data(
         "train_y": train_y,
         "val_X": val_X,
         "val_y": val_y,
+        "val_X_intact": val_X_intact,
+        "val_X_indicating_mask": val_X_indicating_mask,
         "test_X": test_X,
         "test_y": test_y,
         "test_X_intact": test_X_intact,
@@ -104,6 +110,11 @@ def gene_physionet2012():
     test_y = y[y.index.isin(test_set_ids)]
     train_y, val_y, test_y = train_y.to_numpy(), val_y.to_numpy(), test_y.to_numpy()
 
+    # mask values in the validation set as ground truth
+    val_X_intact, val_X, val_X_missing_mask, val_X_indicating_mask = mcar(val_X, 0.1)
+    val_X = masked_fill(val_X, 1 - val_X_missing_mask, torch.nan)
+
+    # mask values in the test set as ground truth
     test_X_intact, test_X, test_X_missing_mask, test_X_indicating_mask = mcar(
         test_X, 0.1
     )
@@ -117,6 +128,8 @@ def gene_physionet2012():
         "train_y": train_y.flatten(),
         "val_X": val_X,
         "val_y": val_y.flatten(),
+        "val_X_intact": val_X_intact,
+        "val_X_indicating_mask": val_X_indicating_mask,
         "test_X": test_X,
         "test_y": test_y.flatten(),
         "test_X_intact": test_X_intact,


### PR DESCRIPTION
In this PR, I simplified the input of `pypots.imputation.base.base.py()` by removing arguments `val_X_intact` and `val_indicating_mask`. The two removed data arguments should be included in the input `val_set`of `fit()` in imputation models, namely, there should be `X_intact` and `indicating_mask` in the `val_set` no matter it is a dictionary or an HDF5 file.

Minorly, in this PR, I also added a daily testing workflow to regularly run all test cases with environment dependencies managed by `pip` rather than `conda`.