### PR TITLE
Fix the error of non-valid license classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Education",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: GNU General Public License version 3",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
The previous license classifier `License :: OSI Approved :: GNU General Public License version 3` was refused while trying to publish on PyPI. Now modify it as `License :: OSI Approved :: GNU General Public License v3 (GPLv3)`. Note that the list of PyPI recognized classifiers is [here](https://pypi.org/classifiers).