### PR TITLE
Fix bugs in the code-coverage report

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,7 +49,7 @@ jobs:
                   python -m pytest -rA pypots/tests/test_forecasting.py -n auto --cov=pypots --cov-append --dist=loadgroup
                   python -m pytest -rA pypots/tests/test_data.py -n auto --cov=pypots --cov-append --dist=loadgroup
                   python -m pytest -rA pypots/tests/test_utils.py -n auto --cov=pypots --cov-append --dist=loadgroup
-                  # python -m pytest -rA pypots/tests/test_cli.py -n auto --cov=pypots --cov-append --dist=loadgroup
+                  python -m pytest -rA pypots/tests/test_cli.py -n auto --cov=pypots --cov-append --dist=loadgroup
 
             - name: Generate the LCOV report
               run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,7 +49,7 @@ jobs:
                   python -m pytest -rA pypots/tests/test_forecasting.py -n auto --cov=pypots --cov-append --dist=loadgroup
                   python -m pytest -rA pypots/tests/test_data.py -n auto --cov=pypots --cov-append --dist=loadgroup
                   python -m pytest -rA pypots/tests/test_utils.py -n auto --cov=pypots --cov-append --dist=loadgroup
-                  python -m pytest -rA pypots/tests/test_cli.py -n auto --cov=pypots --cov-append --dist=loadgroup
+                  # python -m pytest -rA pypots/tests/test_cli.py -n auto --cov=pypots --cov-append --dist=loadgroup
 
             - name: Generate the LCOV report
               run: |

--- a/pypots/tests/test_cli.py
+++ b/pypots/tests/test_cli.py
@@ -13,7 +13,7 @@ from copy import copy
 
 import pytest
 
-from pypots.cli.dev import dev_command_factory
+# from pypots.cli.dev import dev_command_factory
 from pypots.cli.doc import doc_command_factory
 from pypots.cli.env import env_command_factory
 from pypots.utils.logging import logger
@@ -42,63 +42,63 @@ def time_out(interval, callback):
     return decorator
 
 
-class TestPyPOTSCLIDev(unittest.TestCase):
-    # set up the default arguments
-    default_arguments = {
-        "build": False,
-        "cleanup": False,
-        "run_tests": False,
-        "k": None,
-        "show_coverage": False,
-        "lint_code": False,
-    }
-    # `pypots-cli dev` must run under the project root dir
-    os.chdir(PROJECT_ROOT_DIR)
-
-    @pytest.mark.xdist_group(name="cli-dev")
-    def test_0_build(self):
-        arguments = copy(self.default_arguments)
-        arguments["build"] = True
-        args = Namespace(**arguments)
-        dev_command_factory(args).run()
-
-        logger.info("run again under a non-root dir")
-        try:
-            os.chdir(os.path.abspath(os.path.join(PROJECT_ROOT_DIR, "pypots")))
-            dev_command_factory(args).run()
-        except RuntimeError:  # try to run under a non-root dir, so RuntimeError will be raised
-            pass
-        except Exception as e:  # other exceptions will cause an error and result in failed testing
-            raise e
-        finally:
-            os.chdir(PROJECT_ROOT_DIR)
-
-    @pytest.mark.xdist_group(name="cli-dev")
-    def test_1_run_tests(self):
-        arguments = copy(self.default_arguments)
-        arguments["run_tests"] = True
-        arguments["k"] = "try_to_find_a_non_existing_test_case"
-        # args = Namespace(**arguments)
-        # try:
-        #     dev_command_factory(args).run()
-        # except RuntimeError:  # try to find a non-existing test case, so RuntimeError will be raised
-        #     pass
-        # except Exception as e:  # other exceptions will cause an error and result in failed testing
-        #     raise e
-
-    @pytest.mark.xdist_group(name="cli-dev")
-    def test_2_lint_code(self):
-        arguments = copy(self.default_arguments)
-        arguments["lint_code"] = True
-        args = Namespace(**arguments)
-        dev_command_factory(args).run()
-
-    @pytest.mark.xdist_group(name="cli-dev")
-    def test_3_cleanup(self):
-        arguments = copy(self.default_arguments)
-        arguments["cleanup"] = True
-        args = Namespace(**arguments)
-        dev_command_factory(args).run()
+# class TestPyPOTSCLIDev(unittest.TestCase):
+#     # set up the default arguments
+#     default_arguments = {
+#         "build": False,
+#         "cleanup": False,
+#         "run_tests": False,
+#         "k": None,
+#         "show_coverage": False,
+#         "lint_code": False,
+#     }
+#     # `pypots-cli dev` must run under the project root dir
+#     os.chdir(PROJECT_ROOT_DIR)
+#
+#     @pytest.mark.xdist_group(name="cli-dev")
+#     def test_0_build(self):
+#         arguments = copy(self.default_arguments)
+#         arguments["build"] = True
+#         args = Namespace(**arguments)
+#         dev_command_factory(args).run()
+#
+#         logger.info("run again under a non-root dir")
+#         try:
+#             os.chdir(os.path.abspath(os.path.join(PROJECT_ROOT_DIR, "pypots")))
+#             dev_command_factory(args).run()
+#         except RuntimeError:  # try to run under a non-root dir, so RuntimeError will be raised
+#             pass
+#         except Exception as e:  # other exceptions will cause an error and result in failed testing
+#             raise e
+#         finally:
+#             os.chdir(PROJECT_ROOT_DIR)
+#
+#     @pytest.mark.xdist_group(name="cli-dev")
+#     def test_1_run_tests(self):
+#         arguments = copy(self.default_arguments)
+#         arguments["run_tests"] = True
+#         arguments["k"] = "try_to_find_a_non_existing_test_case"
+#         # args = Namespace(**arguments)
+#         # try:
+#         #     dev_command_factory(args).run()
+#         # except RuntimeError:  # try to find a non-existing test case, so RuntimeError will be raised
+#         #     pass
+#         # except Exception as e:  # other exceptions will cause an error and result in failed testing
+#         #     raise e
+#
+#     @pytest.mark.xdist_group(name="cli-dev")
+#     def test_2_lint_code(self):
+#         arguments = copy(self.default_arguments)
+#         arguments["lint_code"] = True
+#         args = Namespace(**arguments)
+#         dev_command_factory(args).run()
+#
+#     @pytest.mark.xdist_group(name="cli-dev")
+#     def test_3_cleanup(self):
+#         arguments = copy(self.default_arguments)
+#         arguments["cleanup"] = True
+#         args = Namespace(**arguments)
+#         dev_command_factory(args).run()
 
 
 class TestPyPOTSCLIDoc(unittest.TestCase):

--- a/pypots/tests/test_cli.py
+++ b/pypots/tests/test_cli.py
@@ -78,13 +78,13 @@ class TestPyPOTSCLIDev(unittest.TestCase):
         arguments = copy(self.default_arguments)
         arguments["run_tests"] = True
         arguments["k"] = "try_to_find_a_non_existing_test_case"
-        args = Namespace(**arguments)
-        try:
-            dev_command_factory(args).run()
-        except RuntimeError:  # try to find a non-existing test case, so RuntimeError will be raised
-            pass
-        except Exception as e:  # other exceptions will cause an error and result in failed testing
-            raise e
+        # args = Namespace(**arguments)
+        # try:
+        #     dev_command_factory(args).run()
+        # except RuntimeError:  # try to find a non-existing test case, so RuntimeError will be raised
+        #     pass
+        # except Exception as e:  # other exceptions will cause an error and result in failed testing
+        #     raise e
 
     @pytest.mark.xdist_group(name="cli-dev")
     def test_2_lint_code(self):

--- a/pypots/tests/test_cli.py
+++ b/pypots/tests/test_cli.py
@@ -13,7 +13,7 @@ from copy import copy
 
 import pytest
 
-# from pypots.cli.dev import dev_command_factory
+from pypots.cli.dev import dev_command_factory
 from pypots.cli.doc import doc_command_factory
 from pypots.cli.env import env_command_factory
 from pypots.utils.logging import logger
@@ -42,63 +42,53 @@ def time_out(interval, callback):
     return decorator
 
 
-# class TestPyPOTSCLIDev(unittest.TestCase):
-#     # set up the default arguments
-#     default_arguments = {
-#         "build": False,
-#         "cleanup": False,
-#         "run_tests": False,
-#         "k": None,
-#         "show_coverage": False,
-#         "lint_code": False,
-#     }
-#     # `pypots-cli dev` must run under the project root dir
-#     os.chdir(PROJECT_ROOT_DIR)
-#
-#     @pytest.mark.xdist_group(name="cli-dev")
-#     def test_0_build(self):
-#         arguments = copy(self.default_arguments)
-#         arguments["build"] = True
-#         args = Namespace(**arguments)
-#         dev_command_factory(args).run()
-#
-#         logger.info("run again under a non-root dir")
-#         try:
-#             os.chdir(os.path.abspath(os.path.join(PROJECT_ROOT_DIR, "pypots")))
-#             dev_command_factory(args).run()
-#         except RuntimeError:  # try to run under a non-root dir, so RuntimeError will be raised
-#             pass
-#         except Exception as e:  # other exceptions will cause an error and result in failed testing
-#             raise e
-#         finally:
-#             os.chdir(PROJECT_ROOT_DIR)
-#
-#     @pytest.mark.xdist_group(name="cli-dev")
-#     def test_1_run_tests(self):
-#         arguments = copy(self.default_arguments)
-#         arguments["run_tests"] = True
-#         arguments["k"] = "try_to_find_a_non_existing_test_case"
-#         # args = Namespace(**arguments)
-#         # try:
-#         #     dev_command_factory(args).run()
-#         # except RuntimeError:  # try to find a non-existing test case, so RuntimeError will be raised
-#         #     pass
-#         # except Exception as e:  # other exceptions will cause an error and result in failed testing
-#         #     raise e
-#
-#     @pytest.mark.xdist_group(name="cli-dev")
-#     def test_2_lint_code(self):
-#         arguments = copy(self.default_arguments)
-#         arguments["lint_code"] = True
-#         args = Namespace(**arguments)
-#         dev_command_factory(args).run()
-#
-#     @pytest.mark.xdist_group(name="cli-dev")
-#     def test_3_cleanup(self):
-#         arguments = copy(self.default_arguments)
-#         arguments["cleanup"] = True
-#         args = Namespace(**arguments)
-#         dev_command_factory(args).run()
+class TestPyPOTSCLIDev(unittest.TestCase):
+    # set up the default arguments
+    default_arguments = {
+        "build": False,
+        "cleanup": False,
+        "run_tests": False,
+        "k": None,
+        "show_coverage": False,
+        "lint_code": False,
+    }
+    # `pypots-cli dev` must run under the project root dir
+    os.chdir(PROJECT_ROOT_DIR)
+
+    @pytest.mark.xdist_group(name="cli-dev")
+    def test_0_build(self):
+        arguments = copy(self.default_arguments)
+        arguments["build"] = True
+        args = Namespace(**arguments)
+        dev_command_factory(args).run()
+
+    @pytest.mark.xdist_group(name="cli-dev")
+    def test_1_run_tests(self):
+        arguments = copy(self.default_arguments)
+        arguments["run_tests"] = True
+        arguments["k"] = "try_to_find_a_non_existing_test_case"
+        args = Namespace(**arguments)
+        try:
+            dev_command_factory(args).run()
+        except RuntimeError:  # try to find a non-existing test case, so RuntimeError will be raised
+            pass
+        except Exception as e:  # other exceptions will cause an error and result in failed testing
+            raise e
+
+    # Don't test --lint-code because Black will reformat the code and cause error when generating the coverage report
+    # @pytest.mark.xdist_group(name="cli-dev")
+    # def test_2_lint_code(self):
+    #     arguments = copy(self.default_arguments)
+    #     arguments["lint_code"] = True
+    #     args = Namespace(**arguments)
+    #     dev_command_factory(args).run()
+
+    @pytest.mark.xdist_group(name="cli-dev")
+    def test_3_cleanup(self):
+        arguments = copy(self.default_arguments)
+        arguments["cleanup"] = True
+        args = Namespace(**arguments)
+        dev_command_factory(args).run()
 
 
 class TestPyPOTSCLIDoc(unittest.TestCase):


### PR DESCRIPTION
This PR is to fix previous bugs the testing cases in `test_cli.py` that are 

1. deleting `.coverage` file causes the mis-calculation of the code coverage;
2. linting code with Black reformats the code and results in discrepancy between records in the `.coverage` file and actual code;

Both fixed in this PR.