### PR TITLE
Fix dependency error in daily testing

### DIFF
--- a/.github/workflows/testing_daily.yml
+++ b/.github/workflows/testing_daily.yml
@@ -1,6 +1,9 @@
 name: Daily Testing
 
 on:
+    push:
+        branches:
+            - fix_dependency_error_in_daily_testing
     schedule:
         # https://crontab.guru. Run everyday at 0:00AM UTC, i.e. 08:00AM Beijing, i.e. 08:00PM Montreal (summer time)
         - cron: "0 0 * * *"
@@ -42,8 +45,7 @@ jobs:
             - name: Install other dependencies
               run: |
                   pip install -e ".[optional]" -f "https://data.pyg.org/whl/torch-${{ matrix.torch-version }}+cpu.html"
-                  pip install -e ".[basic]"
-                  pip install -e ".[test]"
+                  pip install -e ".[dev]"
 
             - name: Fetch the test environment details
               run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,8 +23,8 @@ extend-ignore =
 
 # basic dependencies
 basic =
-    numpy>=1.23.3
-    scikit-learn>=0.24.1
+    numpy
+    scikit-learn
     pandas<2.0.0
     torch>=1.10.0
     tensorboard

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author="Wenjie Du",
     author_email="wenjay.du@gmail.com",
     url="https://github.com/WenjieDu/PyPOTS",
-    download_url="https://github.com/WenjieDu/PyPOTS/archive/master.zip",
+    download_url="https://github.com/WenjieDu/PyPOTS/archive/main.zip",
     keywords=[
         "data mining",
         "neural networks",
@@ -39,8 +39,8 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=[
-        "numpy",
-        "scikit-learn",
+        "numpy>=1.23.3",
+        "scikit-learn>=0.24.1",
         "scipy",
         "torch>=1.10.0",
         "tensorboard",

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=[
-        "numpy>=1.23.3",
-        "scikit-learn>=0.24.1",
+        "numpy",
+        "scikit-learn",
         "scipy",
         "torch>=1.10.0",
         "tensorboard",


### PR DESCRIPTION
In this PR, I removed the version limitations on numpy and sklearn, and installed the dependencies in the scope of `dev` for the workflow `DailyTesting`.