### PR TITLE
Enable different model saving strategies with argument `model_saving_strategy`

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -18,23 +18,21 @@ jobs:
         repo-token: ${{ secrets.ACCESS_TOKEN }}
         issue-message: |
           Hi there 👋,
-          
+
           Thank you so much for your attention to PyPOTS! If you find PyPOTS helpful to your work, please star⭐️ this repository. Your star is your recognition, which can help more people notice PyPOTS and grow PyPOTS community. It matters and is definitely a kind of contribution to the community.
-          
+
           I have received your message and will respond ASAP. Thank you for your patience! 😃
-          
+
           Best,
           Wenjie
 
         pr-message: |
           Hi there 👋,
-          
-          Thank you for your contribution to PyPOTS!
-          
-          If you are trying to fix a bug, please reference the issue number in the description or give your details about the bug. 
+
+          We really really appreciate that you have taken the time to make this PR on PyPOTS!
+
+          If you are trying to fix a bug, please reference the issue number in the description or give your details about the bug.
           If you are implementing a feature request, please check with the maintainers that the feature will be accepted first.
-          
+
           Best,
           Wenjie
-          
-          

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,4 +22,5 @@ build:
          - python -m pip install --upgrade pip
          - pip install torch==1.13.1 -f https://download.pytorch.org/whl/cpu
          - pip install -e ".[optional]" -f "https://data.pyg.org/whl/torch-1.13.1+cpu.html"
-         - pip install -e ".[basic,doc]"
+         - pip install -e ".[basic]"
+         - pip install sphinx==6.2.1 docutils==0.19 sphinxcontrib-bibtex furo

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Welcome to PyPOTS docs!
 
 .. image:: https://img.shields.io/badge/join_us-community!-7fecad
    :alt: Community
-   :target: https://github.com/WenjieDu/PyPOTS/blob/main/README.md#-community
+   :target: #id14
 
 .. image:: https://img.shields.io/github/sponsors/wenjiedu?label=Sponsors&color=7bcfa6&logo=githubsponsors
    :alt: GitHub Sponsors
@@ -121,7 +121,7 @@ and you can find them in `BrewedPOTS <https://github.com/WenjieDu/BrewedPOTS>`_.
 Take a look at it now, and brew your POTS dataset into a cup of coffee! 🤓
 
 If you have further questions, please refer to PyPOTS documentation 📑 `docs.pypots.com <https://docs.pypots.com>`_.
-Besides, you can also `raise an issue <https://github.com/WenjieDu/PyPOTS/issues>`_ or `ask in our community <#community>`_.
+Besides, you can also `raise an issue <https://github.com/WenjieDu/PyPOTS/issues>`_ or `ask in our community <#id14>`_.
 
 
 ❖ Available Algorithms
@@ -186,10 +186,7 @@ You're very welcome to contribute to this exciting project!
 
 By committing your code, you'll
 
-1. make your well-established model out-of-the-box for PyPOTS users to run (Similar to
-   `Scikit-learn <https://scikit-learn.org/stable/faq.html#what-are-the-inclusion-criteria-for-new-algorithms>`_,
-   we set current inclusion criteria as: the paper should be published for at least 1 year, have 20+ citations,
-   and the usefulness to our users can be claimed);
+1. make your well-established model out-of-the-box for PyPOTS users to run. Take a look at our `inclusion criteria <https://docs.pypots.com/en/latest/faq.html#inclusion-criteria>`_;
 2. be listed as one of `PyPOTS contributors <https://github.com/WenjieDu/PyPOTS/graphs/contributors>`_:
 3. get mentioned in our `release notes <https://github.com/WenjieDu/PyPOTS/releases>`_;
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -33,8 +33,8 @@ dependencies:
     - conda-forge::pytest-xdist
 
     # doc
-    - conda-forge::sphinx ==6.2.1
-    - conda-forge::docutils ==0.19
+    - conda-forge::sphinx
+    - conda-forge::docutils
     - conda-forge::sphinxcontrib-bibtex
     - conda-forge::furo
 

--- a/pypots/base.py
+++ b/pypots/base.py
@@ -28,11 +28,11 @@ class BaseModel(ABC):
         Other devices like Google TPU and Apple Silicon accelerator MPS may be added in the future.
 
     saving_path : str, default = None,
-        The path for automatically saving the trained model and training logs (i.e. loss values recorded during
+        The path for automatically saving model checkpoints and tensorboard files (i.e. loss values recorded during
         training into a tensorboard file). Will not save if not given.
 
     model_saving_strategy : str or None, None or "best" or "better" , default = "best",
-        The strategy to save the trained model. It has to be one of [None, "best", "better"].
+        The strategy to save model checkpoints. It has to be one of [None, "best", "better"].
         No model will be saved when it is set as None.
         The "best" strategy will only automatically save the best model after the training finished.
         The "better" strategy will automatically save the model during training whenever the model performs
@@ -276,6 +276,13 @@ class BaseNNModel(BaseModel):
     saving_path : str, default = None,
         The path to save the tensorboard file, which contains the loss values recorded during training.
 
+    model_saving_strategy : str or None, None or "best" or "better" , default = "best",
+        The strategy to save model checkpoints. It has to be one of [None, "best", "better"].
+        No model will be saved when it is set as None.
+        The "best" strategy will only automatically save the best model after the training finished.
+        The "better" strategy will automatically save the model during training whenever the model performs
+        better than in previous epochs.
+
 
     Attributes
     ---------
@@ -290,7 +297,6 @@ class BaseNNModel(BaseModel):
     best_loss : float, default = inf,
         The criteria to judge whether the model's performance is the best so far.
         Usually the lower, the better.
-
     """
 
     def __init__(
@@ -303,10 +309,9 @@ class BaseNNModel(BaseModel):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
-        auto_save_model: bool = True,
-        model_saving_strategy: str = "best",
+        model_saving_strategy: Optional[str] = "best",
     ):
-        super().__init__(device, saving_path, auto_save_model, model_saving_strategy)
+        super().__init__(device, saving_path, model_saving_strategy)
 
         if patience is None:
             patience = -1  # early stopping on patience won't work if it is set as < 0

--- a/pypots/base.py
+++ b/pypots/base.py
@@ -231,6 +231,8 @@ class BaseModel(ABC):
         you can load the model directly with torch.load(model_path).
 
         """
+        assert os.path.exists(model_path), f"Model file {model_path} does not exist."
+
         try:
             loaded_model = torch.load(model_path, map_location=self.device)
             if isinstance(loaded_model, torch.nn.Module):

--- a/pypots/base.py
+++ b/pypots/base.py
@@ -31,13 +31,9 @@ class BaseModel(ABC):
         The path for automatically saving the trained model and training logs (i.e. loss values recorded during
         training into a tensorboard file). Will not save if not given.
 
-    auto_save_model : bool, default = True,
-        Whether to automatically save the trained model if `saving_path` is given and not None.
-        Default as True, i.e. the trained model will be automatically saved to `self.saving_path`
-        and users don't have to explicitly invoke function `self.save_model()`.
-
-    saving_strategy : str, "best" or "better" , default = "best",
-        The strategy to save the trained model. It has to be "best" or "better".
+    model_saving_strategy : str or None, None or "best" or "better" , default = "best",
+        The strategy to save the trained model. It has to be one of [None, "best", "better"].
+        No model will be saved when it is set as None.
         The "best" strategy will only automatically save the best model after the training finished.
         The "better" strategy will automatically save the model during training whenever the model performs
         better than in previous epochs.
@@ -60,25 +56,25 @@ class BaseModel(ABC):
 
     # leverage typing to show type hints in IDEs
     # SAVING_STRATEGY = Literal["best", "better"]
-    SAVING_STRATEGY = ["best", "better"]
+    SAVING_STRATEGY = [None, "best", "better"]
 
     def __init__(
         self,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
-        auto_save_model: bool = True,
-        saving_strategy: str = "best",
+        model_saving_strategy: Optional[str] = "best",
     ):
 
-        assert saving_strategy in [
+        assert model_saving_strategy in [
+            None,
             "best",
             "better",
-        ], f"saving_strategy must be one of {self.SAVING_STRATEGY}, but got f{saving_strategy}."
+        ], f"saving_strategy must be one of {self.SAVING_STRATEGY}, but got f{model_saving_strategy}."
 
         self.device = None
         self.saving_path = saving_path
-        self.auto_save_model = auto_save_model
-        self.saving_strategy = saving_strategy
+        self.model_saving_strategy = model_saving_strategy
+
         self.model = None
         self.summary_writer = None
 
@@ -212,13 +208,12 @@ class BaseModel(ABC):
             The file name of the saved model.
 
         """
-        if self.saving_path is not None and self.auto_save_model:
+        if self.saving_path is not None and self.model_saving_strategy is not None:
             name = self.__class__.__name__ if saving_name is None else saving_name
-            if not training_finished and self.saving_strategy == "better":
+            if not training_finished and self.model_saving_strategy == "better":
                 self.save_model(self.saving_path, name)
-            elif training_finished and self.saving_strategy == "best":
+            elif training_finished and self.model_saving_strategy == "best":
                 self.save_model(self.saving_path, name)
-
         else:
             return
 
@@ -308,8 +303,10 @@ class BaseNNModel(BaseModel):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        auto_save_model: bool = True,
+        model_saving_strategy: str = "best",
     ):
-        super().__init__(device, saving_path)
+        super().__init__(device, saving_path, auto_save_model, model_saving_strategy)
 
         if patience is None:
             patience = -1  # early stopping on patience won't work if it is set as < 0

--- a/pypots/classification/base.py
+++ b/pypots/classification/base.py
@@ -108,6 +108,7 @@ class BaseNNClassifier(BaseNNModel, BaseClassifier):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             batch_size,
@@ -118,6 +119,7 @@ class BaseNNClassifier(BaseNNModel, BaseClassifier):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
         self.n_classes = n_classes
 

--- a/pypots/classification/base.py
+++ b/pypots/classification/base.py
@@ -30,10 +30,12 @@ class BaseClassifier(BaseModel):
         self,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             device,
             saving_path,
+            model_saving_strategy,
         )
 
     @abstractmethod

--- a/pypots/classification/brits.py
+++ b/pypots/classification/brits.py
@@ -159,6 +159,7 @@ class BRITS(BaseNNClassifier):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             n_classes,
@@ -170,6 +171,7 @@ class BRITS(BaseNNClassifier):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
 
         self.n_steps = n_steps

--- a/pypots/classification/grud.py
+++ b/pypots/classification/grud.py
@@ -141,6 +141,7 @@ class GRUD(BaseNNClassifier):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             n_classes,
@@ -152,6 +153,7 @@ class GRUD(BaseNNClassifier):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
 
         self.n_steps = n_steps

--- a/pypots/classification/raindrop.py
+++ b/pypots/classification/raindrop.py
@@ -643,6 +643,7 @@ class Raindrop(BaseNNClassifier):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             n_classes,
@@ -654,6 +655,7 @@ class Raindrop(BaseNNClassifier):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
 
         self.n_features = n_features

--- a/pypots/clustering/base.py
+++ b/pypots/clustering/base.py
@@ -24,10 +24,12 @@ class BaseClusterer(BaseModel):
         self,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             device,
             saving_path,
+            model_saving_strategy,
         )
 
     @abstractmethod

--- a/pypots/clustering/base.py
+++ b/pypots/clustering/base.py
@@ -70,10 +70,6 @@ class BaseClusterer(BaseModel):
         file_type : str, default = "h5py"
             The type of the given file if X is a path string.
 
-        num_workers : int, default = 0,
-            The number of subprocesses to use for data loading.
-            `0` means data loading will be in the main process, i.e. there won't be subprocesses.
-
         Returns
         -------
         array-like, shape [n_samples],
@@ -94,6 +90,7 @@ class BaseNNClusterer(BaseNNModel, BaseClusterer):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             batch_size,
@@ -104,6 +101,7 @@ class BaseNNClusterer(BaseNNModel, BaseClusterer):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
         self.n_clusters = n_clusters
 

--- a/pypots/clustering/crli.py
+++ b/pypots/clustering/crli.py
@@ -348,6 +348,7 @@ class CRLI(BaseNNClusterer):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             n_clusters,
@@ -359,6 +360,7 @@ class CRLI(BaseNNClusterer):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
         assert G_steps > 0 and D_steps > 0, "G_steps and D_steps should both >0"
 

--- a/pypots/clustering/vader.py
+++ b/pypots/clustering/vader.py
@@ -393,6 +393,7 @@ class VaDER(BaseNNClusterer):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             n_clusters,
@@ -404,6 +405,7 @@ class VaDER(BaseNNClusterer):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
         self.n_steps = n_steps
         self.n_features = n_features

--- a/pypots/forecasting/base.py
+++ b/pypots/forecasting/base.py
@@ -24,10 +24,12 @@ class BaseForecaster(BaseModel):
         self,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             device,
             saving_path,
+            model_saving_strategy,
         )
 
     @abstractmethod

--- a/pypots/imputation/base.py
+++ b/pypots/imputation/base.py
@@ -43,10 +43,12 @@ class BaseImputer(BaseModel):
         self,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             device,
             saving_path,
+            model_saving_strategy,
         )
 
     @abstractmethod

--- a/pypots/imputation/base.py
+++ b/pypots/imputation/base.py
@@ -35,7 +35,8 @@ class BaseImputer(BaseModel):
         to train ML models. Other devices like Google TPU and Apple Silicon accelerator MPS may be added in the future.
 
     saving_path : str, default = None,
-        The path to save the tensorboard file, which contains the loss values recorded during training.
+        The path to save model checkpoints and tensorboard files,
+        which contains the loss values recorded during training.
     """
 
     def __init__(
@@ -133,7 +134,9 @@ class BaseNNImputer(BaseNNModel, BaseImputer):
         to train ML models. Other devices like Google TPU and Apple Silicon accelerator MPS may be added in the future.
 
     saving_path : str, default = None,
-        The path to save the tensorboard file, which contains the loss values recorded during training.
+        The path for automatically saving model checkpoints and tensorboard files (i.e. loss values recorded during
+        training into a tensorboard file). Will not save if not given.
+
     """
 
     def __init__(
@@ -146,6 +149,7 @@ class BaseNNImputer(BaseNNModel, BaseImputer):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             batch_size,
@@ -156,6 +160,7 @@ class BaseNNImputer(BaseNNModel, BaseImputer):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
 
     @abstractmethod

--- a/pypots/imputation/brits.py
+++ b/pypots/imputation/brits.py
@@ -508,6 +508,18 @@ class BRITS(BaseNNImputer):
 
     device :
         Run the model on which device.
+
+    saving_path : str, default = None,
+        The path for automatically saving model checkpoints and tensorboard files (i.e. loss values recorded during
+        training into a tensorboard file). Will not save if not given.
+
+    model_saving_strategy : str or None, None or "best" or "better" , default = "best",
+        The strategy to save model checkpoints. It has to be one of [None, "best", "better"].
+        No model will be saved when it is set as None.
+        The "best" strategy will only automatically save the best model after the training finished.
+        The "better" strategy will automatically save the model during training whenever the model performs
+        better than in previous epochs.
+
     """
 
     def __init__(
@@ -523,6 +535,7 @@ class BRITS(BaseNNImputer):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             batch_size,
@@ -533,6 +546,7 @@ class BRITS(BaseNNImputer):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
 
         self.n_steps = n_steps

--- a/pypots/imputation/saits.py
+++ b/pypots/imputation/saits.py
@@ -191,7 +191,17 @@ class SAITS(BaseNNImputer):
     weight_decay
     num_workers
     device
-    saving_path
+
+    saving_path : str, default = None,
+        The path for automatically saving model checkpoints and tensorboard files (i.e. loss values recorded during
+        training into a tensorboard file). Will not save if not given.
+
+    model_saving_strategy : str or None, None or "best" or "better" , default = "best",
+        The strategy to save model checkpoints. It has to be one of [None, "best", "better"].
+        No model will be saved when it is set as None.
+        The "best" strategy will only automatically save the best model after the training finished.
+        The "better" strategy will automatically save the model during training whenever the model performs
+        better than in previous epochs.
     """
 
     def __init__(
@@ -216,6 +226,7 @@ class SAITS(BaseNNImputer):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             batch_size,
@@ -226,6 +237,7 @@ class SAITS(BaseNNImputer):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
 
         self.n_steps = n_steps

--- a/pypots/imputation/transformer.py
+++ b/pypots/imputation/transformer.py
@@ -301,6 +301,7 @@ class Transformer(BaseNNImputer):
         num_workers: int = 0,
         device: Optional[Union[str, torch.device]] = None,
         saving_path: str = None,
+        model_saving_strategy: Optional[str] = "best",
     ):
         super().__init__(
             batch_size,
@@ -311,6 +312,7 @@ class Transformer(BaseNNImputer):
             num_workers,
             device,
             saving_path,
+            model_saving_strategy,
         )
 
         self.n_steps = n_steps

--- a/pypots/tests/global_test_config.py
+++ b/pypots/tests/global_test_config.py
@@ -5,6 +5,7 @@ The global configurations for test cases.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: GLP-v3
 
+import os
 
 from pypots.data.generating import gene_incomplete_random_walk_dataset
 
@@ -17,3 +18,16 @@ DATA_SAVING_DIR = "h5data_for_tests"
 
 # tensorboard and model files saving directory
 RESULT_SAVING_DIR = "testing_results"
+
+
+def check_tb_and_model_checkpoints_existence(model):
+    # check the tensorboard file existence
+    saved_files = os.listdir(model.saving_path)
+    if ".DS_Store" in saved_files:  # for macOS
+        saved_files.remove(".DS_Store")
+    assert (
+        model.saving_path is not None and len(saved_files) > 0
+    ), "tensorboard file does not exist"
+    # check the model checkpoints existence
+    saved_model_files = [i for i in saved_files if i.endswith(".pypots")]
+    assert len(saved_model_files) > 0, "No model checkpoint saved."

--- a/pypots/tests/test_classification.py
+++ b/pypots/tests/test_classification.py
@@ -11,7 +11,11 @@ import unittest
 import pytest
 
 from pypots.classification import BRITS, GRUD, Raindrop
-from pypots.tests.global_test_config import DATA, RESULT_SAVING_DIR
+from pypots.tests.global_test_config import (
+    DATA,
+    RESULT_SAVING_DIR,
+    check_tb_and_model_checkpoints_existence,
+)
 from pypots.utils.logging import logger
 from pypots.utils.metrics import cal_binary_classification_metrics
 
@@ -39,6 +43,7 @@ class TestBRITS(unittest.TestCase):
         n_classes=DATA["n_classes"],
         epochs=EPOCHS,
         saving_path=saving_path,
+        model_saving_strategy="better",
     )
 
     @pytest.mark.xdist_group(name="classification-brits")
@@ -79,20 +84,17 @@ class TestBRITS(unittest.TestCase):
             self.saving_path
         ), f"file {self.saving_path} does not exist"
 
-        # whether the tensorboard file exists
-        assert (
-            self.brits.saving_path is not None
-            and len(os.listdir(self.brits.saving_path)) > 0
-        ), "tensorboard file does not exist"
+        # check if the tensorboard file and model checkpoints exist
+        check_tb_and_model_checkpoints_existence(self.brits)
 
         # save the trained model into file, and check if the path exists
         self.brits.save_model(
             saving_dir=self.saving_path, file_name=self.model_save_name
         )
+
+        # test loading the saved model, not necessary, but need to test
         saved_model_path = os.path.join(self.saving_path, self.model_save_name)
-        assert os.path.exists(
-            saved_model_path
-        ), f"file {self.saving_path} does not exist, model not saved"
+        self.brits.load_model(saved_model_path)
 
 
 class TestGRUD(unittest.TestCase):
@@ -150,20 +152,17 @@ class TestGRUD(unittest.TestCase):
             self.saving_path
         ), f"file {self.saving_path} does not exist"
 
-        # whether the tensorboard file exists
-        assert (
-            self.grud.saving_path is not None
-            and len(os.listdir(self.grud.saving_path)) > 0
-        ), "tensorboard file does not exist"
+        # check if the tensorboard file and model checkpoints exist
+        check_tb_and_model_checkpoints_existence(self.grud)
 
         # save the trained model into file, and check if the path exists
         self.grud.save_model(
             saving_dir=self.saving_path, file_name=self.model_save_name
         )
+
+        # test loading the saved model, not necessary, but need to test
         saved_model_path = os.path.join(self.saving_path, self.model_save_name)
-        assert os.path.exists(
-            saved_model_path
-        ), f"file {self.saving_path} does not exist, model not saved"
+        self.grud.load_model(saved_model_path)
 
 
 class TestRaindrop(unittest.TestCase):
@@ -231,20 +230,17 @@ class TestRaindrop(unittest.TestCase):
             self.saving_path
         ), f"file {self.saving_path} does not exist"
 
-        # whether the tensorboard file exists
-        assert (
-            self.raindrop.saving_path is not None
-            and len(os.listdir(self.raindrop.saving_path)) > 0
-        ), "tensorboard file does not exist"
+        # check if the tensorboard file and model checkpoints exist
+        check_tb_and_model_checkpoints_existence(self.raindrop)
 
         # save the trained model into file, and check if the path exists
         self.raindrop.save_model(
             saving_dir=self.saving_path, file_name=self.model_save_name
         )
+
+        # test loading the saved model, not necessary, but need to test
         saved_model_path = os.path.join(self.saving_path, self.model_save_name)
-        assert os.path.exists(
-            saved_model_path
-        ), f"file {self.saving_path} does not exist, model not saved"
+        self.raindrop.load_model(saved_model_path)
 
 
 if __name__ == "__main__":

--- a/pypots/tests/test_clustering.py
+++ b/pypots/tests/test_clustering.py
@@ -13,7 +13,11 @@ import pytest
 import os
 
 from pypots.clustering import VaDER, CRLI
-from pypots.tests.global_test_config import DATA, RESULT_SAVING_DIR
+from pypots.tests.global_test_config import (
+    DATA,
+    RESULT_SAVING_DIR,
+    check_tb_and_model_checkpoints_existence,
+)
 from pypots.utils.logging import logger
 from pypots.utils.metrics import cal_rand_index, cal_cluster_purity
 
@@ -77,20 +81,17 @@ class TestCRLI(unittest.TestCase):
             self.saving_path
         ), f"file {self.saving_path} does not exist"
 
-        # whether the tensorboard file exists
-        assert (
-            self.crli.saving_path is not None
-            and len(os.listdir(self.crli.saving_path)) > 0
-        ), "tensorboard file does not exist"
+        # check if the tensorboard file and model checkpoints exist
+        check_tb_and_model_checkpoints_existence(self.crli)
 
         # save the trained model into file, and check if the path exists
         self.crli.save_model(
             saving_dir=self.saving_path, file_name=self.model_save_name
         )
+
+        # test loading the saved model, not necessary, but need to test
         saved_model_path = os.path.join(self.saving_path, self.model_save_name)
-        assert os.path.exists(
-            saved_model_path
-        ), f"file {self.saving_path} does not exist, model not saved"
+        self.crli.load_model(saved_model_path)
 
 
 class TestVaDER(unittest.TestCase):
@@ -150,20 +151,17 @@ class TestVaDER(unittest.TestCase):
             self.saving_path
         ), f"file {self.saving_path} does not exist"
 
-        # whether the tensorboard file exists
-        assert (
-            self.vader.saving_path is not None
-            and len(os.listdir(self.vader.saving_path)) > 0
-        ), "tensorboard file does not exist"
+        # check if the tensorboard file and model checkpoints exist
+        check_tb_and_model_checkpoints_existence(self.vader)
 
         # save the trained model into file, and check if the path exists
         self.vader.save_model(
             saving_dir=self.saving_path, file_name=self.model_save_name
         )
+
+        # test loading the saved model, not necessary, but need to test
         saved_model_path = os.path.join(self.saving_path, self.model_save_name)
-        assert os.path.exists(
-            saved_model_path
-        ), f"file {self.saving_path} does not exist, model not saved"
+        self.vader.load_model(saved_model_path)
 
 
 if __name__ == "__main__":

--- a/pypots/tests/test_imputation.py
+++ b/pypots/tests/test_imputation.py
@@ -18,7 +18,11 @@ from pypots.imputation import (
     BRITS,
     LOCF,
 )
-from pypots.tests.global_test_config import DATA, RESULT_SAVING_DIR
+from pypots.tests.global_test_config import (
+    DATA,
+    RESULT_SAVING_DIR,
+    check_tb_and_model_checkpoints_existence,
+)
 from pypots.utils.logging import logger
 from pypots.utils.metrics import cal_mae
 
@@ -93,20 +97,17 @@ class TestSAITS(unittest.TestCase):
             self.saving_path
         ), f"file {self.saving_path} does not exist"
 
-        # whether the tensorboard file exists
-        assert (
-            self.saits.saving_path is not None
-            and len(os.listdir(self.saits.saving_path)) > 0
-        ), "tensorboard file does not exist"
+        # check if the tensorboard file and model checkpoints exist
+        check_tb_and_model_checkpoints_existence(self.saits)
 
         # save the trained model into file, and check if the path exists
         self.saits.save_model(
             saving_dir=self.saving_path, file_name=self.model_save_name
         )
+
+        # test loading the saved model, not necessary, but need to test
         saved_model_path = os.path.join(self.saving_path, self.model_save_name)
-        assert os.path.exists(
-            saved_model_path
-        ), f"file {self.saving_path} does not exist, model not saved"
+        self.saits.load_model(saved_model_path)
 
 
 class TestTransformer(unittest.TestCase):
@@ -170,20 +171,17 @@ class TestTransformer(unittest.TestCase):
             self.saving_path
         ), f"file {self.saving_path} does not exist"
 
-        # whether the tensorboard file exists
-        assert (
-            self.transformer.saving_path is not None
-            and len(os.listdir(self.transformer.saving_path)) > 0
-        ), "tensorboard file does not exist"
+        # check if the tensorboard file and model checkpoints exist
+        check_tb_and_model_checkpoints_existence(self.transformer)
 
         # save the trained model into file, and check if the path exists
         self.transformer.save_model(
             saving_dir=self.saving_path, file_name=self.model_save_name
         )
+
+        # test loading the saved model, not necessary, but need to test
         saved_model_path = os.path.join(self.saving_path, self.model_save_name)
-        assert os.path.exists(
-            saved_model_path
-        ), f"file {self.saving_path} does not exist, model not saved"
+        self.transformer.load_model(saved_model_path)
 
 
 class TestBRITS(unittest.TestCase):
@@ -238,20 +236,17 @@ class TestBRITS(unittest.TestCase):
             self.saving_path
         ), f"file {self.saving_path} does not exist"
 
-        # whether the tensorboard file exists
-        assert (
-            self.brits.saving_path is not None
-            and len(os.listdir(self.brits.saving_path)) > 0
-        ), "tensorboard file does not exist"
+        # check if the tensorboard file and model checkpoints exist
+        check_tb_and_model_checkpoints_existence(self.brits)
 
         # save the trained model into file, and check if the path exists
         self.brits.save_model(
             saving_dir=self.saving_path, file_name=self.model_save_name
         )
+
+        # test loading the saved model, not necessary, but need to test
         saved_model_path = os.path.join(self.saving_path, self.model_save_name)
-        assert os.path.exists(
-            saved_model_path
-        ), f"file {self.saving_path} does not exist, model not saved"
+        self.brits.load_model(saved_model_path)
 
 
 class TestLOCF(unittest.TestCase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,8 +52,7 @@ test =
 
 # dependencies for documentation generating
 doc =
-    sphinx==6.2.1
-    docutils==0.19
+    sphinx
     sphinxcontrib-bibtex
     furo
 


### PR DESCRIPTION
# What does this PR do?

1. add argument `model_saving_strategy` for all models to enable different model saving strategies;
2. update test cases, test loading the saved model;


## Before submitting
- [ ] This PR is made to fix a typo or improve the docs (you can dismiss the other checks if this is the case).
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
