### PR TITLE
Should use package `pypots` as the source for code coverage calculation, rather than `tests`

### DIFF
--- a/.github/workflows/testing_daily.yml
+++ b/.github/workflows/testing_daily.yml
@@ -52,7 +52,7 @@ jobs:
 
             - name: Test with pytest
               run: |
-                  coverage run --source=tests -m pytest
+                  coverage run --source=pypots -m pytest
 
             - name: Generate the LCOV report
               run: |


### PR DESCRIPTION
# What does this PR do?

* Fixes #100 , which is for daily-testing workflow, not including ci-testing workflow;


## Before submitting
- [x] This PR is made to fix a typo or improve the docs (you can dismiss the other checks if this is the case).
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
