### PR TITLE
Add `.coveragerc` to omit files in templates

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,3 @@
 [run]
 omit =
-    tests/*
-    pypots/*/template/*
+    */template/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [run]
-omit = pypots/*/template/*
+omit =
+    tests/*
+    pypots/*/template/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = pypots/*/template/*

--- a/.github/workflows/testing_ci.yml
+++ b/.github/workflows/testing_ci.yml
@@ -43,14 +43,14 @@ jobs:
               run: |
                   # run tests separately here due to Segmentation Fault in test_clustering when run all in
                   # one command with `pytest` on MacOS. Bugs not caught, so this is a trade-off to avoid SF.
-                  python -m pytest -rA tests/test_classification.py -n auto --cov=pypots --dist=loadgroup
-                  python -m pytest -rA tests/test_imputation.py -n auto --cov=pypots --cov-append --dist=loadgroup
-                  python -m pytest -rA tests/test_clustering.py -n auto --cov=pypots --cov-append --dist=loadgroup
-                  python -m pytest -rA tests/test_forecasting.py -n auto --cov=pypots --cov-append --dist=loadgroup
-                  python -m pytest -rA tests/test_optim.py -n auto --cov=pypots --cov-append --dist=loadgroup
-                  python -m pytest -rA tests/test_data.py -n auto --cov=pypots --cov-append --dist=loadgroup
-                  python -m pytest -rA tests/test_utils.py -n auto --cov=pypots --cov-append --dist=loadgroup
-                  python -m pytest -rA tests/test_cli.py -n auto --cov=pypots --cov-append --dist=loadgroup
+                  python -m pytest -rA tests/test_classification.py -n auto --cov=pypots --dist=loadgroup --cov-config=.coveragerc
+                  python -m pytest -rA tests/test_imputation.py -n auto --cov=pypots --cov-append --dist=loadgroup --cov-config=.coveragerc
+                  python -m pytest -rA tests/test_clustering.py -n auto --cov=pypots --cov-append --dist=loadgroup --cov-config=.coveragerc
+                  python -m pytest -rA tests/test_forecasting.py -n auto --cov=pypots --cov-append --dist=loadgroup --cov-config=.coveragerc
+                  python -m pytest -rA tests/test_optim.py -n auto --cov=pypots --cov-append --dist=loadgroup --cov-config=.coveragerc
+                  python -m pytest -rA tests/test_data.py -n auto --cov=pypots --cov-append --dist=loadgroup --cov-config=.coveragerc
+                  python -m pytest -rA tests/test_utils.py -n auto --cov=pypots --cov-append --dist=loadgroup --cov-config=.coveragerc
+                  python -m pytest -rA tests/test_cli.py -n auto --cov=pypots --cov-append --dist=loadgroup --cov-config=.coveragerc
 
             - name: Generate the LCOV report
               run: |


### PR DESCRIPTION
# What does this PR do?

Add `.coveragerc` to omit files in templates from coverage calculation.

## Before submitting
- [x] This PR is made to fix a typo or improve the docs (you can dismiss the other checks if this is the case).
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
