### PR TITLE
Use `setup` instead of `build` to build release

### DIFF
--- a/.github/workflows/publish_to_PyPI.yml
+++ b/.github/workflows/publish_to_PyPI.yml
@@ -10,6 +10,10 @@
 name: Publish to PyPI
 
 on:
+  push:
+    branches:
+      - release
+
   release:
     types: [published]
 
@@ -46,7 +50,8 @@ jobs:
         pip list
 
     - name: Build package
-      run: python -m build
+      run: |
+        python setup.py sdist bdist_wheel
 
     - name: Publish the new package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.6


### PR DESCRIPTION
# What does this PR do?

* fix: use setup instead of build;

To fix the error returned by PyPI website:
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/ Only one sdist may be uploaded per release.


## Before submitting
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
