### PR TITLE
skip multi-gpu test if not multi-gpu host

### DIFF
--- a/tests/test_training_on_multi_gpus.py
+++ b/tests/test_training_on_multi_gpus.py
@@ -37,7 +37,7 @@ from tests.global_test_config import (
 EPOCHS = 5
 
 DEVICES = [torch.device(i) for i in range(torch.cuda.device_count())]
-LESS_THAN_TWO_DEVICES = len(DEVICES) < 1
+LESS_THAN_TWO_DEVICES = len(DEVICES) < 2
 
 # global skip test if less than two cuda-enabled devices
 pytestmark = pytest.mark.skipif(LESS_THAN_TWO_DEVICES, reason="not enough cuda devices")

--- a/tests/test_training_on_multi_gpus.py
+++ b/tests/test_training_on_multi_gpus.py
@@ -12,6 +12,8 @@ import unittest
 import numpy as np
 import pytest
 
+import torch
+
 from pypots.classification import BRITS, GRUD, Raindrop
 from pypots.clustering import VaDER, CRLI
 from pypots.forecasting import BTTF
@@ -33,7 +35,12 @@ from tests.global_test_config import (
 )
 
 EPOCHS = 5
-DEVICES = ["cuda:0", "cuda:1"]
+
+DEVICES = [torch.device(i) for i in range(torch.cuda.device_count())]
+LESS_THAN_TWO_DEVICES = len(DEVICES) < 1
+
+# global skip test if less than two cuda-enabled devices
+pytestmark = pytest.mark.skipif(LESS_THAN_TWO_DEVICES, reason="not enough cuda devices")
 
 
 TRAIN_SET = {"X": DATA["train_X"], "y": DATA["train_y"]}


### PR DESCRIPTION
# What does this PR do?

<!--
Congrats! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution 😉.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, I will review your PR shortly. I may suggest changes to make the code even better 🤝.
-->

<!-- Remove if not applicable -->

Fixes #123  (issue)
If tests are run with a brutal global `pytest`, they fail if the host machine has less than two cuda-enabled devices. This is almost expected, since we want to test multi-gpu behaviour, but this makes local development difficult on laptops or zero/single gpu machines.
I propose skipping the module alltogether if the machine has less than two cuda-enabled devices.
As a bonus, I disable the upper cap of 2 cuda devices - let's test all of them!


## Before submitting

<!-- You can remove checks that are not relevant to this PR. -->

- [ ] This PR is made to fix a typo or improve the docs (you can dismiss the other checks if this is the case).
- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case. #123 
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
