### PR TITLE
Fix single-item device list throwing an error

### DIFF
--- a/pypots/base.py
+++ b/pypots/base.py
@@ -81,7 +81,7 @@ class BaseModel(ABC):
         # set up saving_path to save the trained model and training logs
         self._setup_path(saving_path)
 
-    def _setup_device(self, device):
+    def _setup_device(self, device: Union[None, str, torch.device, list]):
         if device is None:
             # if it is None, then use the first cuda device if cuda is available, otherwise use cpu
             if torch.cuda.is_available() and torch.cuda.device_count() > 0:
@@ -95,12 +95,13 @@ class BaseModel(ABC):
             elif isinstance(device, torch.device):
                 self.device = device
             elif isinstance(device, list):
+                if len(device) == 0:
+                    raise ValueError("The list of devices should have at least 1 device, but got 0.")
+                elif len(device) == 1:
+                    return self._setup_device(device[0])
                 # parallely training on multiple CUDA devices
 
                 # ensure the list is not empty
-                assert (
-                    len(device) > 1
-                ), "The list of devices should have at least 1 device, but got 0."
 
                 device_list = []
                 for idx, d in enumerate(device):


### PR DESCRIPTION
# Fix single item device list throwing an error

I noticed that if I pass a list containing a single item as `device` to any model that derives from `BaseModel` it results in an AssertionError, which I think is erroneous.
`AssertionError: The list of devices should have at least 1 device, but got 0.`

I test if the `device` variable is one item long. If it is, I extract the object it contains and rerun `self._setup_device` recursively.

## Before submitting

<!-- You can remove checks that are not relevant to this PR. -->

- [ ] This PR is made to fix a typo or improve the docs (you can dismiss the other checks if this is the case).
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
