### PR TITLE
Visualize attention matrix in SAITS

### DIFF
--- a/pypots/utils/visual/visualizeAttention.py
+++ b/pypots/utils/visual/visualizeAttention.py
@@ -29,7 +29,7 @@ def visualize_attention(timeSteps: ArrayLike, attention: np.ndarray, fontscale =
     if not all(isinstance(ele, str) for ele in timeSteps):
         timeSteps = [str(step) for step in timeSteps]
 
-    if font_scale is not None:
+    if fontscale is not None:
         sns.set_theme(font_scale = fontscale)
 
     fig, ax = plt.subplots()

--- a/pypots/utils/visual/visualizeAttention.py
+++ b/pypots/utils/visual/visualizeAttention.py
@@ -4,7 +4,7 @@ import seaborn as sns
 from numpy.typing import ArrayLike
 
 
-def visualize_attention(timeSteps: ArrayLike, attention: np.ndarray):
+def visualize_attention(timeSteps: ArrayLike, attention: np.ndarray, fontscale = None):
     """Visualize the map of attention weights from Transformer-based models
 
     Parameters
@@ -16,6 +16,9 @@ def visualize_attention(timeSteps: ArrayLike, attention: np.ndarray):
     attention: 2D array-like object
         A 2D matrix representing the attention weights
 
+    fontscale: float/int
+        Sets the scale for fonts in the Seaborn heatmap (applied to sns.set_theme(font_scale = _)
+
 
     Return
     ---------------
@@ -24,10 +27,13 @@ def visualize_attention(timeSteps: ArrayLike, attention: np.ndarray):
     """
 
     if not all(isinstance(ele, str) for ele in timeSteps):
-        timeSteps = [str(timeSteps) for _ in timeSteps]
+        timeSteps = [str(step) for step in timeSteps]
+
+    if font_scale is not None:
+        sns.set_theme(font_scale = fontscale)
 
     fig, ax = plt.subplots()
-    ax.tickparams(left=True, bottom=True, labelsize=10)
+    ax.tick_params(left=True, bottom=True, labelsize=10)
     ax.set_xticks(ax.get_xticks()[::2])
     ax.set_yticks(ax.get_yticks()[::2])
 
@@ -43,4 +49,4 @@ def visualize_attention(timeSteps: ArrayLike, attention: np.ndarray):
     cb = ax.collections[0].colorbar
     cb.ax.tick_params(labelsize=10)
 
-    return ax
+    return fig

--- a/pypots/utils/visual/visualizeAttention.py
+++ b/pypots/utils/visual/visualizeAttention.py
@@ -1,17 +1,17 @@
-import seaborn as sns
-import matplotlib as mpl
 import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
 from numpy.typing import ArrayLike
-import numppy as np
 
 
-def visualizeAttention(timeSteps: ArrayLike, attention: np.ndarray):
-    """Visualize the attention matrix
+def visualize_attention(timeSteps: ArrayLike, attention: np.ndarray):
+    """Visualize the map of attention weights from Transformer-based models
 
     Parameters
     ---------------
     timeSteps: 1D array-like object, preferable list of strings
-        A vector containing the time steps of the input. The time steps will be converted to a list of strings if they are not already.
+        A vector containing the time steps of the input. 
+        The time steps will be converted to a list of strings if they are not already.
 
     attention: 2D array-like object
         A 2D matrix representing the attention weights
@@ -24,7 +24,7 @@ def visualizeAttention(timeSteps: ArrayLike, attention: np.ndarray):
     """
 
     if not all(isinstance(ele, str) for ele in timeSteps):
-        timeSteps = [str(timeSteps) for step in timeSteps]
+        timeSteps = [str(timeSteps) for _ in timeSteps]
 
     fig, ax = plt.subplots()
     ax.tickparams(left=True, bottom=True, labelsize=10)

--- a/pypots/utils/visual/visualizeAttention.py
+++ b/pypots/utils/visual/visualizeAttention.py
@@ -1,0 +1,46 @@
+import seaborn as sns
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from numpy.typing import ArrayLike
+import numppy as np
+
+
+def visualizeAttention(timeSteps: ArrayLike, attention: np.ndarray):
+    """Visualize the attention matrix
+
+    Parameters
+    ---------------
+    timeSteps: 1D array-like object, preferable list of strings
+        A vector containing the time steps of the input. The time steps will be converted to a list of strings if they are not already.
+
+    attention: 2D array-like object
+        A 2D matrix representing the attention weights
+
+
+    Return
+    ---------------
+    ax: Matplotlib axes object
+
+    """
+
+    if not all(isinstance(ele, str) for ele in timeSteps):
+        timeSteps = [str(timeSteps) for step in timeSteps]
+
+    fig, ax = plt.subplots()
+    ax.tickparams(left=True, bottom=True, labelsize=10)
+    ax.set_xticks(ax.get_xticks()[::2])
+    ax.set_yticks(ax.get_yticks()[::2])
+
+    assert attention.ndim == 2, "The attention matrix is not two-dimensional"
+    sns.heatmap(
+        attention,
+        ax=ax,
+        xticklabels=timeSteps,
+        yticklabels=timeSteps,
+        linewidths=0,
+        cbar=True,
+    )
+    cb = ax.collections[0].colorbar
+    cb.ax.tick_params(labelsize=10)
+
+    return ax


### PR DESCRIPTION
Added file visualizeAttention.py to pypots.utils.visual for visualization of attention matrix from DMSA heads of SAITS.
The required dependencies are: numpy, seaborn, matplotlib

Fixing #178

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
