### PR TITLE
Apply SAITS loss to new models

### DIFF
--- a/pypots/imputation/autoformer/model.py
+++ b/pypots/imputation/autoformer/model.py
@@ -63,6 +63,12 @@ class Autoformer(BaseNNImputer):
     dropout :
         The dropout rate for the model.
 
+    ORT_weight :
+        The weight for the ORT loss, the same as SAITS.
+
+    MIT_weight :
+        The weight for the MIT loss, the same as SAITS.
+
     batch_size :
         The batch size for training and evaluating the model.
 
@@ -115,6 +121,8 @@ class Autoformer(BaseNNImputer):
         factor: int,
         moving_avg_window_size: int,
         dropout: float = 0,
+        ORT_weight: float = 1,
+        MIT_weight: float = 1,
         batch_size: int = 32,
         epochs: int = 100,
         patience: int = None,
@@ -144,6 +152,8 @@ class Autoformer(BaseNNImputer):
         self.factor = factor
         self.moving_avg_window_size = moving_avg_window_size
         self.dropout = dropout
+        self.ORT_weight = ORT_weight
+        self.MIT_weight = MIT_weight
 
         # set up the model
         self.model = _Autoformer(
@@ -156,6 +166,8 @@ class Autoformer(BaseNNImputer):
             self.factor,
             self.moving_avg_window_size,
             self.dropout,
+            self.ORT_weight,
+            self.MIT_weight,
         )
         self._send_model_to_given_device()
         self._print_model_size()

--- a/pypots/imputation/autoformer/modules/submodules.py
+++ b/pypots/imputation/autoformer/modules/submodules.py
@@ -24,17 +24,11 @@ class AutoCorrelation(nn.Module):
 
     def __init__(
         self,
-        mask_flag=True,
         factor=1,
-        scale=None,
         attention_dropout=0.1,
-        output_attention=False,
     ):
         super().__init__()
         self.factor = factor
-        self.scale = scale
-        self.mask_flag = mask_flag
-        self.output_attention = output_attention
         self.dropout = nn.Dropout(attention_dropout)
 
     def time_delay_agg_training(self, values, corr):
@@ -165,10 +159,7 @@ class AutoCorrelation(nn.Module):
                 values.permute(0, 2, 3, 1).contiguous(), corr
             ).permute(0, 3, 1, 2)
 
-        if self.output_attention:
-            return (V.contiguous(), corr.permute(0, 3, 1, 2))
-        else:
-            return (V.contiguous(), None)
+        return V.contiguous(), corr.permute(0, 3, 1, 2)
 
 
 class AutoCorrelationLayer(nn.Module):

--- a/pypots/imputation/crossformer/model.py
+++ b/pypots/imputation/crossformer/model.py
@@ -67,6 +67,12 @@ class Crossformer(BaseNNImputer):
     dropout :
         The dropout rate for the model.
 
+    ORT_weight :
+        The weight for the ORT loss, the same as SAITS.
+
+    MIT_weight :
+        The weight for the MIT loss, the same as SAITS.
+
     batch_size :
         The batch size for training and evaluating the model.
 
@@ -120,6 +126,8 @@ class Crossformer(BaseNNImputer):
         seg_len: int,
         win_size: int,
         dropout: float = 0,
+        ORT_weight: float = 1,
+        MIT_weight: float = 1,
         batch_size: int = 32,
         epochs: int = 100,
         patience: int = None,
@@ -150,6 +158,8 @@ class Crossformer(BaseNNImputer):
         self.seg_len = seg_len
         self.win_size = win_size
         self.dropout = dropout
+        self.ORT_weight = ORT_weight
+        self.MIT_weight = MIT_weight
 
         # set up the model
         self.model = _Crossformer(
@@ -163,6 +173,8 @@ class Crossformer(BaseNNImputer):
             self.seg_len,
             self.win_size,
             self.dropout,
+            self.ORT_weight,
+            self.MIT_weight,
         )
         self._send_model_to_given_device()
         self._print_model_size()

--- a/pypots/imputation/dlinear/model.py
+++ b/pypots/imputation/dlinear/model.py
@@ -53,6 +53,12 @@ class DLinear(BaseNNImputer):
         The dimension of the space in which the time-series data will be embedded and modeled.
         It is necessary only for DLinear in the non-individual mode.
 
+    ORT_weight :
+        The weight for the ORT loss, the same as SAITS.
+
+    MIT_weight :
+        The weight for the MIT loss, the same as SAITS.
+
     batch_size :
         The batch size for training and evaluating the model.
 
@@ -101,6 +107,8 @@ class DLinear(BaseNNImputer):
         moving_avg_window_size: int,
         individual: bool = False,
         d_model: Optional[int] = None,
+        ORT_weight: float = 1,
+        MIT_weight: float = 1,
         batch_size: int = 32,
         epochs: int = 100,
         patience: int = None,
@@ -126,14 +134,18 @@ class DLinear(BaseNNImputer):
         self.moving_avg_window_size = moving_avg_window_size
         self.individual = individual
         self.d_model = d_model
+        self.ORT_weight = ORT_weight
+        self.MIT_weight = MIT_weight
 
         # set up the model
         self.model = _DLinear(
-            n_steps,
-            n_features,
-            moving_avg_window_size,
-            individual,
-            d_model,
+            self.n_steps,
+            self.n_features,
+            self.moving_avg_window_size,
+            self.individual,
+            self.d_model,
+            self.ORT_weight,
+            self.MIT_weight,
         )
         self._send_model_to_given_device()
         self._print_model_size()

--- a/pypots/imputation/etsformer/model.py
+++ b/pypots/imputation/etsformer/model.py
@@ -63,6 +63,12 @@ class ETSformer(BaseNNImputer):
     dropout :
         The dropout rate for the model.
 
+    ORT_weight :
+        The weight for the ORT loss, the same as SAITS.
+
+    MIT_weight :
+        The weight for the MIT loss, the same as SAITS.
+
     batch_size :
         The batch size for training and evaluating the model.
 
@@ -115,6 +121,8 @@ class ETSformer(BaseNNImputer):
         d_ffn,
         top_k,
         dropout: float = 0,
+        ORT_weight: float = 1,
+        MIT_weight: float = 1,
         batch_size: int = 32,
         epochs: int = 100,
         patience: int = None,
@@ -144,6 +152,8 @@ class ETSformer(BaseNNImputer):
         self.d_ffn = d_ffn
         self.dropout = dropout
         self.top_k = top_k
+        self.ORT_weight = ORT_weight
+        self.MIT_weight = MIT_weight
 
         # set up the model
         self.model = _ETSformer(
@@ -156,6 +166,8 @@ class ETSformer(BaseNNImputer):
             self.d_ffn,
             self.dropout,
             self.top_k,
+            self.ORT_weight,
+            self.MIT_weight,
         )
         self._send_model_to_given_device()
         self._print_model_size()

--- a/pypots/imputation/fedformer/model.py
+++ b/pypots/imputation/fedformer/model.py
@@ -71,6 +71,12 @@ class FEDformer(BaseNNImputer):
         Get modes on frequency domain. It has to "random" or "low". The default value is "random".
         'random' means sampling randomly; 'low' means sampling the lowest modes;
 
+    ORT_weight :
+        The weight for the ORT loss, the same as SAITS.
+
+    MIT_weight :
+        The weight for the MIT loss, the same as SAITS.
+
     batch_size :
         The batch size for training and evaluating the model.
 
@@ -125,6 +131,8 @@ class FEDformer(BaseNNImputer):
         version="Fourier",
         modes=32,
         mode_select="random",
+        ORT_weight: float = 1,
+        MIT_weight: float = 1,
         batch_size: int = 32,
         epochs: int = 100,
         patience: int = None,
@@ -151,11 +159,13 @@ class FEDformer(BaseNNImputer):
         self.n_heads = n_heads
         self.d_model = d_model
         self.d_ffn = d_ffn
-        self.modes = modes
-        self.mode_select = mode_select
         self.moving_avg_window_size = moving_avg_window_size
         self.dropout = dropout
         self.version = version
+        self.modes = modes
+        self.mode_select = mode_select
+        self.ORT_weight = ORT_weight
+        self.MIT_weight = MIT_weight
 
         # set up the model
         self.model = _FEDformer(
@@ -170,6 +180,8 @@ class FEDformer(BaseNNImputer):
             self.version,
             self.modes,
             self.mode_select,
+            self.ORT_weight,
+            self.MIT_weight,
         )
         self._send_model_to_given_device()
         self._print_model_size()

--- a/pypots/imputation/informer/model.py
+++ b/pypots/imputation/informer/model.py
@@ -61,6 +61,12 @@ class Informer(BaseNNImputer):
     dropout :
         The dropout rate for the model.
 
+    ORT_weight :
+        The weight for the ORT loss, the same as SAITS.
+
+    MIT_weight :
+        The weight for the MIT loss, the same as SAITS.
+
     batch_size :
         The batch size for training and evaluating the model.
 
@@ -112,6 +118,8 @@ class Informer(BaseNNImputer):
         d_ffn: int,
         factor: int,
         dropout: float = 0,
+        ORT_weight: float = 1,
+        MIT_weight: float = 1,
         batch_size: int = 32,
         epochs: int = 100,
         patience: int = None,
@@ -140,6 +148,8 @@ class Informer(BaseNNImputer):
         self.d_ffn = d_ffn
         self.factor = factor
         self.dropout = dropout
+        self.ORT_weight = ORT_weight
+        self.MIT_weight = MIT_weight
 
         # set up the model
         self.model = _Informer(
@@ -151,6 +161,8 @@ class Informer(BaseNNImputer):
             self.d_ffn,
             self.factor,
             self.dropout,
+            self.ORT_weight,
+            self.MIT_weight,
         )
         self._send_model_to_given_device()
         self._print_model_size()

--- a/pypots/imputation/informer/modules/submodules.py
+++ b/pypots/imputation/informer/modules/submodules.py
@@ -60,15 +60,13 @@ class ProbAttention(AttentionOperator):
         self,
         mask_flag=True,
         factor=5,
-        scale=None,
         attention_dropout=0.1,
-        output_attention=False,
+        scale=None,
     ):
         super().__init__()
         self.factor = factor
         self.scale = scale
         self.mask_flag = mask_flag
-        self.output_attention = output_attention
         self.dropout = nn.Dropout(attention_dropout)
 
     def _prob_QK(self, Q, K, sample_k, n_top):  # n_top: c*ln(L_q)
@@ -121,14 +119,12 @@ class ProbAttention(AttentionOperator):
         context_in[
             torch.arange(B)[:, None, None], torch.arange(H)[None, :, None], index, :
         ] = torch.matmul(attn, V).type_as(context_in)
-        if self.output_attention:
-            attns = (torch.ones([B, H, L_V, L_V]) / L_V).type_as(attn).to(attn.device)
-            attns[
-                torch.arange(B)[:, None, None], torch.arange(H)[None, :, None], index, :
-            ] = attn
-            return (context_in, attns)
-        else:
-            return (context_in, None)
+
+        attns = (torch.ones([B, H, L_V, L_V]) / L_V).type_as(attn).to(attn.device)
+        attns[
+            torch.arange(B)[:, None, None], torch.arange(H)[None, :, None], index, :
+        ] = attn
+        return context_in, attns
 
     def forward(
         self,

--- a/pypots/imputation/patchtst/model.py
+++ b/pypots/imputation/patchtst/model.py
@@ -73,6 +73,12 @@ class PatchTST(BaseNNImputer):
     dropout :
         The dropout rate for the model.
 
+    ORT_weight :
+        The weight for the ORT loss, the same as SAITS.
+
+    MIT_weight :
+        The weight for the MIT loss, the same as SAITS.
+
     batch_size :
         The batch size for training and evaluating the model.
 
@@ -128,6 +134,8 @@ class PatchTST(BaseNNImputer):
         d_ffn: int,
         dropout: float,
         attn_dropout: float,
+        ORT_weight: float = 1,
+        MIT_weight: float = 1,
         batch_size: int = 32,
         epochs: int = 100,
         patience: int = None,
@@ -169,6 +177,8 @@ class PatchTST(BaseNNImputer):
         self.d_ffn = d_ffn
         self.dropout = dropout
         self.attn_dropout = attn_dropout
+        self.ORT_weight = ORT_weight
+        self.MIT_weight = MIT_weight
 
         # set up the model
         self.model = _PatchTST(
@@ -184,6 +194,8 @@ class PatchTST(BaseNNImputer):
             self.stride,
             self.dropout,
             self.attn_dropout,
+            self.ORT_weight,
+            self.MIT_weight,
         )
         self._send_model_to_given_device()
         self._print_model_size()


### PR DESCRIPTION
<!-- 🚨Please create your PR to merge code from your branch to `dev` branch here, rather than `main`. -->

# What does this PR do?

<!--
Congrats! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution 😉.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, I will review your PR shortly. I may suggest changes to make the code even better 🤝.
-->

<!-- Remove if not applicable -->

1. apply both ORT and MIT loss from SAITS paper to newly added models (Crossformer, PatchTST, DLinear, ETSformer, FEDformer, Informer, and Autoformer), and add loss weight arguments to balance them. Previously, the seven models are trained only with MIT loss;

## Before submitting

<!-- You can remove checks that are not relevant to this PR. -->

- [x] This PR is made to fix a typo or improve the docs (you can dismiss the other checks if this is the case).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
