### PR TITLE
Avoid the import error `MessagePassing not defined`

### DIFF
--- a/.github/workflows/testing_ci.yml
+++ b/.github/workflows/testing_ci.yml
@@ -55,6 +55,15 @@ jobs:
             - name: Install other dependencies
               run: |
                   pip install -r requirements.txt
+
+            - name: Test building package
+              # we need to know if the package can be built successfully without optional dependencies
+              run: |
+                  pip install build wheel
+                  python -m build --no-isolation
+
+            - name: Continue to install torch-geometric dependencies
+              run: |
                   pip install torch-geometric torch-scatter torch-sparse -f "https://data.pyg.org/whl/torch-${{ steps.determine_pytorch_ver.outputs.value }}+cpu.html"
                   pip install pypots[dev]
                   python_site_path=`python -c "import site; print(site.getsitepackages()[0])"`

--- a/pypots/nn/modules/raindrop/__init__.py
+++ b/pypots/nn/modules/raindrop/__init__.py
@@ -13,9 +13,7 @@ In ICLR, 2022.
 # License: BSD-3-Clause
 
 from .backbone import BackboneRaindrop
-from .layers import ObservationPropagation
 
 __all__ = [
     "BackboneRaindrop",
-    "ObservationPropagation",
 ]


### PR DESCRIPTION
<!-- 🚨Please create your PR to merge code from your branch to `dev` branch here, rather than `main`. -->

# What does this PR do?

<!--
Congrats! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution 😉.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, I will review your PR shortly. I may suggest changes to make the code even better 🤝.
-->

<!-- Remove if not applicable -->
1. fixing #352;
2. in previous commits, we expose ObservationPropagation in the below line, but this will cause the exception`name 'MessagePassing' is not defined` if torch_geometric is not installed. We remove this line in this PR to fix this issue. https://github.com/WenjieDu/PyPOTS/blob/aecd14b331a70c52f9174064b28ddf91445832ce/pypots/nn/modules/raindrop/__init__.py#L16
