### PR TITLE
Fix wrong dim when concatenating eval labels in pypots.classification.base

### DIFF
--- a/pypots/classification/base.py
+++ b/pypots/classification/base.py
@@ -351,8 +351,8 @@ class BaseNNClassifier(BaseNNModel):
                             epoch_val_pred_collector.append(results["classification_pred"])
                             epoch_val_label_collector.append(inputs["y"])
 
-                    epoch_val_pred_collector = torch.cat(epoch_val_pred_collector, dim=-1).cpu().numpy()
-                    epoch_val_label_collector = torch.cat(epoch_val_label_collector, dim=-1).cpu().numpy()
+                    epoch_val_pred_collector = torch.cat(epoch_val_pred_collector).cpu().numpy()
+                    epoch_val_label_collector = torch.cat(epoch_val_label_collector).cpu().numpy()
 
                     # TODO: refactor the following code to a function
                     epoch_val_pred_collector = np.argmax(epoch_val_pred_collector, axis=1)


### PR DESCRIPTION
<!-- 🚨Please create your PR to merge code from your branch to `dev` branch here, rather than `main`. -->

# What does this PR do?

<!--
Congrats! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution 😉.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, I will review your PR shortly. I may suggest changes to make the code even better 🤝.
-->

<!-- Remove if not applicable -->

1. fixing #645;


## Before submitting

<!-- You can remove checks that are not relevant to this PR. -->

- [x] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
