### PR TITLE
fix: update threading interface in testing

### DIFF
--- a/tests/cli/dev.py
+++ b/tests/cli/dev.py
@@ -25,7 +25,7 @@ def time_out(interval, callback):
     def decorator(func):
         def wrapper(*args, **kwargs):
             t = threading.Thread(target=func, args=args, kwargs=kwargs)
-            t.setDaemon(True)
+            t.daemon = True
             t.start()
             t.join(interval)  # wait for interval seconds
             if t.is_alive():

--- a/tests/cli/doc.py
+++ b/tests/cli/doc.py
@@ -26,7 +26,7 @@ def time_out(interval, callback):
     def decorator(func):
         def wrapper(*args, **kwargs):
             t = threading.Thread(target=func, args=args, kwargs=kwargs)
-            t.setDaemon(True)
+            t.daemon = True
             t.start()
             t.join(interval)  # wait for interval seconds
             if t.is_alive():


### PR DESCRIPTION
# What does this PR do?
This small PR resolves the `threading` library warnings, which you can find in the [CI logs](https://github.com/WenjieDu/PyPOTS/actions/runs/16137580068/job/45537181538#step:9:2276):
```python
D:\a\PyPOTS\PyPOTS\tests\cli\doc.py:29: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
    t.setDaemon(True)
```

## Before submitting


- [ ] This PR is made to fix a typo or improve the docs (you can dismiss the other checks if this is the case);
- [ ] Was this discussed/approved via a GitHub issue? Please add a link to it if that's the case;
- [ ] I have commented my code, particularly in hard-to-understand areas;
- [ ] I have written the necessary tests and already run them locally;
