### PR TITLE
fix: guard optional validation fields in CSAI forward during inference

### DIFF
--- a/pypots/imputation/csai/core.py
+++ b/pypots/imputation/csai/core.py
@@ -134,7 +134,9 @@ class _BCSAI(ModelCore):
                 results["metric"] = self.validation_metric(reconstruction, X_ori, indicating_mask)
 
         if not self.training:
-            results["x_ori"] = inputs["X_ori"]
-            results["indicating_mask"] = inputs["indicating_mask"]
+            if "X_ori" in inputs:
+                results["x_ori"] = inputs["X_ori"]
+            if "indicating_mask" in inputs:
+                results["indicating_mask"] = inputs["indicating_mask"]
 
         return results


### PR DESCRIPTION
## Description

In `pypots/imputation/csai/core.py`, `_BCSAI.forward` ends with:

```python
if calc_criterion:
    if self.training:
        ...
    else:  # validation stage
        X_ori, indicating_mask = inputs["X_ori"], inputs["indicating_mask"]
        ...

if not self.training:
    results["x_ori"] = inputs["X_ori"]
    results["indicating_mask"] = inputs["indicating_mask"]
```

The first block correctly gates `X_ori` / `indicating_mask` behind
`calc_criterion` (those keys only exist in validation batches). The second
block runs whenever `self.training` is False — including plain `predict()`
calls where the user's `Dataset` has no ground-truth fields — and raises
`KeyError: 'X_ori'` there.

The unconditional accesses were introduced when CSAI was re-landed in PR
#788 and never made it through a predict-only test. This PR restores the
invariant by guarding the accesses so they only fire when the keys actually
exist in the input dict.

## Changes

- `pypots/imputation/csai/core.py`: wrap the `results["x_ori"]` and
  `results["indicating_mask"]` assignments in `if "X_ori" in inputs:` /
  `if "indicating_mask" in inputs:` checks. Semantically identical for any
  caller that already provides those keys (validation); now safe for pure
  inference.

## Testing

- Validation flow is unchanged: when the caller feeds a batch with both
  keys present, both entries are added to `results` just as before.
- Pure-inference flow (user passes only `X`, `missing_mask`, the `deltas_*`
  / `last_obs_*` pair) now returns the regular result dict without raising
  `KeyError`.

No changes to model weights, training loss, or validation metric; the fix
is limited to two safe attribute lookups.
