### PR TITLE
fix: keep TS2Vec classifier_type='linear_regression' working with DeprecationWarning

### DIFF
--- a/pypots/classification/ts2vec/model.py
+++ b/pypots/classification/ts2vec/model.py
@@ -22,6 +22,27 @@ from ...representation.ts2vec.core import _TS2Vec
 
 SUPPORTED_CLASSIFIERS = ["lr", "svm", "knn"]
 
+# Backward-compatibility aliases for classifier_type names that were renamed.
+# Kept so user code written before the rename keeps working for at least one
+# release, with a clear DeprecationWarning pointing to the new name.
+_DEPRECATED_CLASSIFIER_ALIASES = {
+    "linear_regression": "lr",
+}
+
+
+def _resolve_classifier_type(classifier_type: str) -> str:
+    if classifier_type in _DEPRECATED_CLASSIFIER_ALIASES:
+        new_name = _DEPRECATED_CLASSIFIER_ALIASES[classifier_type]
+        warnings.warn(
+            f"classifier_type={classifier_type!r} is deprecated; use "
+            f"{new_name!r} instead. The old name will be removed in a "
+            "future release.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return new_name
+    return classifier_type
+
 
 class TS2Vec(BaseNNClassifier):
     """The PyTorch implementation of the TS2Vec model :cite:`yue2022ts2vec`.
@@ -310,6 +331,7 @@ class TS2Vec(BaseNNClassifier):
             latent variables if necessary.
 
         """
+        classifier_type = _resolve_classifier_type(classifier_type)
         assert (
             classifier_type in SUPPORTED_CLASSIFIERS
         ), f"classifier_type should be one of {SUPPORTED_CLASSIFIERS}, but got {classifier_type}"

--- a/tests/classification/ts2vec.py
+++ b/tests/classification/ts2vec.py
@@ -80,6 +80,7 @@ class TestTS2Vec(unittest.TestCase):
             f'Recall: {metrics["recall"]}'
         )
 
+        _ = self.ts2vec.predict(TEST_SET, classifier_type="linear_regression")
         results = self.ts2vec.predict(TEST_SET, classifier_type="lr")
         metrics = calc_binary_classification_metrics(results["classification_proba"], DATA["test_y"])
         logger.info(


### PR DESCRIPTION
## Description

Commit 1163cae4 (merged as part of PR #798, sklearn 1.7 compatibility)
renamed the TS2Vec `classifier_type` option from `"linear_regression"` to
`"lr"`. The old name was removed without an alias or deprecation warning,
so any user code written against an earlier release now fails silently
with:

```
AssertionError: classifier_type should be one of ['lr', 'svm', 'knn'],
but got linear_regression
```

This PR adds a minimal backward-compatibility shim so the old name keeps
working for at least one release while pointing users at the new spelling.

## Changes

- `pypots/classification/ts2vec/model.py`:
  - introduce `_DEPRECATED_CLASSIFIER_ALIASES = {"linear_regression": "lr"}`
    next to the canonical `SUPPORTED_CLASSIFIERS` list;
  - add a tiny `_resolve_classifier_type()` helper that emits a
    `DeprecationWarning` and returns the new name when a deprecated alias
    is passed;
  - call the helper at the top of `TS2Vec.predict()` (immediately before
    the existing `assert classifier_type in SUPPORTED_CLASSIFIERS` check),
    which is the single entry point shared by `predict()` and
    `classify()`.

`SUPPORTED_CLASSIFIERS` itself is unchanged so the documented list of
supported values stays canonical. The alias can be deleted in a future
release per the usual deprecation cycle.

## Testing

- `classifier_type="lr"`: same behavior as before (no warning, no
  reassignment).
- `classifier_type="linear_regression"`: emits a `DeprecationWarning`
  pointing users at `"lr"`, then proceeds through the existing `lr`
  branch; behavior is identical to what users got before PR #798.
- Unknown values still hit the existing assertion with the same error
  message.

No public API surface is added or removed; this is purely a
compatibility shim that keeps pre-#798 call sites working.
