### PR TITLE
fix: load checkpoints with weights_only when PyTorch supports it

### DIFF
--- a/pypots/base.py
+++ b/pypots/base.py
@@ -6,6 +6,7 @@ The base (abstract) classes for models in PyPOTS.
 # License: BSD-3-Clause
 
 import os
+import inspect
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from datetime import datetime
@@ -25,6 +26,16 @@ try:
     import nni
 except ImportError:
     pass
+
+
+_TORCH_LOAD_SUPPORTS_WEIGHTS_ONLY = "weights_only" in inspect.signature(torch.load).parameters
+
+
+def _load_model_file(path: str, map_location):
+    load_kwargs = {"map_location": map_location}
+    if _TORCH_LOAD_SUPPORTS_WEIGHTS_ONLY:
+        load_kwargs["weights_only"] = True
+    return torch.load(path, **load_kwargs)
 
 
 class BaseModel(ABC):
@@ -376,12 +387,15 @@ class BaseModel(ABC):
         If the training environment and the deploying/test environment use the same type of device (GPU/CPU),
         you can load the model directly with torch.load(model_path).
 
+        On PyTorch versions that support it, PyPOTS loads checkpoint files with ``weights_only=True``
+        so deserializing model state does not execute arbitrary pickle payloads from untrusted files.
+
         """
         assert os.path.exists(path), f"Model file {path} does not exist."
 
         try:
             map_location = self.device[0] if isinstance(self.device, list) else self.device
-            loaded_file = torch.load(path, map_location=map_location)
+            loaded_file = _load_model_file(path, map_location)
 
             if isinstance(loaded_file, torch.nn.Module):  # compatible model for pypots <0.13
                 if isinstance(self.device, torch.device):

--- a/tests/base/test_model_loading.py
+++ b/tests/base/test_model_loading.py
@@ -1,0 +1,60 @@
+"""
+Focused tests for BaseModel.load safety defaults.
+"""
+
+import inspect
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from pypots.base import BaseModel
+
+
+class DummyModel(BaseModel):
+    def __init__(self):
+        super().__init__(device=torch.device("cpu"), verbose=False)
+        self.model = torch.nn.Linear(2, 2)
+
+    def fit(self, train_set, val_set=None, file_type: str = "hdf5"):
+        raise NotImplementedError
+
+    def predict(self, test_set, file_type: str = "hdf5"):
+        raise NotImplementedError
+
+
+class TestBaseModelLoad(unittest.TestCase):
+    def test_load_uses_safe_torch_load_defaults_when_supported(self):
+        model = DummyModel()
+        checkpoint = {"model_state_dict": model.model.state_dict()}
+        supports_weights_only = "weights_only" in inspect.signature(torch.load).parameters
+
+        with tempfile.NamedTemporaryFile(suffix=".pypots") as tmp:
+            torch.save(checkpoint, tmp.name)
+
+            with patch("pypots.base.torch.load", wraps=torch.load) as mocked_torch_load:
+                model.load(tmp.name)
+
+            load_kwargs = mocked_torch_load.call_args.kwargs
+            if supports_weights_only:
+                self.assertIs(load_kwargs["weights_only"], True)
+            else:
+                self.assertNotIn("weights_only", load_kwargs)
+
+    def test_load_restores_saved_state_dict(self):
+        source_model = DummyModel()
+        source_model.model.bias.data.fill_(3.14)
+
+        target_model = DummyModel()
+        target_model.model.bias.data.zero_()
+
+        with tempfile.NamedTemporaryFile(suffix=".pypots") as tmp:
+            torch.save({"model_state_dict": source_model.model.state_dict()}, tmp.name)
+            target_model.load(tmp.name)
+
+        self.assertTrue(torch.allclose(target_model.model.bias, source_model.model.bias))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- load BaseModel checkpoints with `weights_only=True` when the active PyTorch runtime supports that safer path
- keep the existing `load()` API unchanged while centralizing the torch.load kwargs in one helper
- add a focused regression test for both the safe torch.load call contract and successful state-dict restoration

Fixes #836

## Verification
- `source .venv/bin/activate && python -m pytest tests/base/test_model_loading.py -q`

## Notes
- This keeps the secure default narrow and backward-compatible at the API level.
- I did not extend this PR to re-enable unsafe legacy full-module checkpoint loading, since the issue here is the unsafe default path.