### PR TITLE
docs: sync minimum Python version in badges and install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
     <a href="https://docs.pypots.com/en/latest/install.html#reasons-of-version-limitations-on-dependencies">
-       <img alt="Python version" src="https://img.shields.io/badge/Python-v3.8+-F8C6B5?logo=python&logoColor=white">
+       <img alt="Python version" src="https://img.shields.io/badge/Python-v3.9+-F8C6B5?logo=python&logoColor=white">
     </a>
     <a href="https://landscape.pytorch.org/?item=modeling--specialized--pypots">
         <img alt="Pytorch landscape" src="https://img.shields.io/badge/PyTorch%20Landscape-EE4C2C?logo=pytorch&logoColor=white">

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 
 <p align="center">
     <a href="https://docs.pypots.com/en/latest/install.html#reasons-of-version-limitations-on-dependencies">
-       <img alt="Python version" src="https://img.shields.io/badge/Python-v3.8+-F8C6B5?logo=python&logoColor=white">
+       <img alt="Python version" src="https://img.shields.io/badge/Python-v3.9+-F8C6B5?logo=python&logoColor=white">
     </a>
     <a href="https://landscape.pytorch.org/?item=modeling--specialized--pypots">
         <img alt="Pytorch landscape" src="https://img.shields.io/badge/PyTorch%20Landscape-EE4C2C?logo=pytorch&logoColor=white">

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Welcome to PyPOTS docs!
 
 **A Python Toolbox for Machine Learning on Partially-Observed Time Series**
 
-.. image:: https://img.shields.io/badge/Python-v3.8+-E97040?logo=python&logoColor=white
+.. image:: https://img.shields.io/badge/Python-v3.9+-E97040?logo=python&logoColor=white
    :alt: Python version
    :target: https://docs.pypots.com/en/latest/install.html#reasons-of-version-limitations-on-dependencies
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -26,7 +26,7 @@ It is recommended to use **pip** or **conda** for PyPOTS installation as shown b
 
 Required Dependencies
 """""""""""""""""""""
-* Python >=3.8
+* Python >=3.9
 * h5py
 * numpy
 * scipy
@@ -54,13 +54,13 @@ Optional Dependencies
 
 Reasons of Version Limitations on Dependencies
 **********************************************
-* **Why we need python >=3.8?**
+* **Why we need python >=3.9?**
 
-Python v3.6 and before versions have no longer been supported officially (check out `status of Python versions here <https://devguide.python.org/versions/>`_).
+Python v3.8 and before versions have no longer been supported officially (check out `status of Python versions here <https://devguide.python.org/versions/>`_).
 Besides, PyG (torch-geometric) is available for Python >= v3.7 (refer to https://pytorch-geometric.readthedocs.io/en/latest/install/installation.html#installation-via-anaconda ).
 Although torch-geometric is an optional dependency, we hope things go smoothly when our users opt to install it.
-In addition, note that Python v.3.7 has also been in the end-of-life status since 2023-06-27.
-Hence, we raise the minimum support Python version to v3.8.
+In addition, note that Python v3.8 has also been in the end-of-life status since 2024-10-07.
+Hence, we raise the minimum support Python version to v3.9.
 
 * **Why we need PyTorch >=1.10?**
 


### PR DESCRIPTION
## Summary

- update the README and README_zh Python badges from `v3.8+` to `v3.9+`
- update the docs index badge and installation guide minimum Python version to match `pyproject.toml`
- refresh the version-limit rationale to mention Python 3.8 EOL

## Validation

- `python -W error::SyntaxWarning -m compileall -q pypots tests`
- `rg -n "Python-v3\.8\+|Python >=3\.8|python >=3\.8|minimum support Python version to v3\.8" README.md README_zh.md docs pyproject.toml` returned no matches